### PR TITLE
Removing use of C#6 feature. Can build with .NET 4

### DIFF
--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -482,9 +482,14 @@ namespace SQLQueryStress
                             finally
                             {
                                 //Clean up the connection
-                                if (_statsComm != null && conn != null)
-                                    conn.InfoMessage -= handler;
-                                conn?.Close();
+                                if (conn != null)
+                                {
+                                    if (_statsComm != null)
+                                    {
+                                        conn.InfoMessage -= handler;               
+                                    }
+                                    conn.Close();    
+                                }
                             }
 
                             var finished = i == _iterations - 1;

--- a/src/SQLQueryStress/SqlControl.xaml.cs
+++ b/src/SQLQueryStress/SqlControl.xaml.cs
@@ -38,7 +38,8 @@ namespace SQLQueryStress
             }
             finally
             {
-                stream?.Dispose();
+                if (stream != null)
+                    stream.Dispose();    
             }
         }
     }


### PR DESCRIPTION
Hi Erik.
Just a suggestion so the project can build i VS2013. Doesn't seem like a huge need for C#6 features so far. 
