### PR TITLE
Add option to kill active queries when the Cancel button is pressed

### DIFF
--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -128,7 +128,7 @@ namespace SQLQueryStress
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(733, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(741, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -141,39 +141,39 @@ namespace SQLQueryStress
             this.loadSettingsToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(142, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(137, 6);
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.optionsToolStripMenuItem.Text = "Options";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // saveSettingsToolStripMenuItem
             // 
             this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
-            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.saveSettingsToolStripMenuItem.Text = "Save Settings";
             this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
             // 
             // loadSettingsToolStripMenuItem
             // 
             this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
-            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.loadSettingsToolStripMenuItem.Text = "Load Settings";
             this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -182,13 +182,13 @@ namespace SQLQueryStress
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -535,7 +535,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 9);
             this.tableLayoutPanel1.Controls.Add(this.queryDelay_textBox, 0, 10);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(326, 3);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(334, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 15;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 52F));
@@ -690,7 +690,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(733, 410);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(741, 410);
             this.tableLayoutPanel3.TabIndex = 33;
             // 
             // elementHost1
@@ -698,7 +698,7 @@ namespace SQLQueryStress
             this.elementHost1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.elementHost1.Location = new System.Drawing.Point(3, 3);
             this.elementHost1.Name = "elementHost1";
-            this.elementHost1.Size = new System.Drawing.Size(317, 404);
+            this.elementHost1.Size = new System.Drawing.Size(325, 404);
             this.elementHost1.TabIndex = 33;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
@@ -708,7 +708,7 @@ namespace SQLQueryStress
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(733, 434);
+            this.ClientSize = new System.Drawing.Size(741, 434);
             this.Controls.Add(this.tableLayoutPanel3);
             this.Controls.Add(this.db_label);
             this.Controls.Add(this.label1);

--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -128,7 +128,7 @@ namespace SQLQueryStress
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(741, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(733, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -141,39 +141,39 @@ namespace SQLQueryStress
             this.loadSettingsToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(137, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(142, 6);
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
             this.optionsToolStripMenuItem.Text = "Options";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // saveSettingsToolStripMenuItem
             // 
             this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
-            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
             this.saveSettingsToolStripMenuItem.Text = "Save Settings";
             this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
             // 
             // loadSettingsToolStripMenuItem
             // 
             this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
-            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
             this.loadSettingsToolStripMenuItem.Text = "Load Settings";
             this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -182,13 +182,13 @@ namespace SQLQueryStress
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -535,7 +535,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 9);
             this.tableLayoutPanel1.Controls.Add(this.queryDelay_textBox, 0, 10);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(334, 3);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(326, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 15;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 52F));
@@ -690,7 +690,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(741, 410);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(733, 410);
             this.tableLayoutPanel3.TabIndex = 33;
             // 
             // elementHost1
@@ -698,7 +698,7 @@ namespace SQLQueryStress
             this.elementHost1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.elementHost1.Location = new System.Drawing.Point(3, 3);
             this.elementHost1.Name = "elementHost1";
-            this.elementHost1.Size = new System.Drawing.Size(325, 404);
+            this.elementHost1.Size = new System.Drawing.Size(317, 404);
             this.elementHost1.TabIndex = 33;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
@@ -708,7 +708,7 @@ namespace SQLQueryStress
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(741, 434);
+            this.ClientSize = new System.Drawing.Size(733, 434);
             this.Controls.Add(this.tableLayoutPanel3);
             this.Controls.Add(this.db_label);
             this.Controls.Add(this.label1);

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -284,8 +284,7 @@ namespace SQLQueryStress
 
             var engine = new LoadEngine(_settings.MainDbConnectionInfo.ConnectionString, _settings.MainQuery, _settings.NumThreads, _settings.NumIterations,
                 _settings.ParamQuery, _settings.ParamMappings, paramConnectionInfo.ConnectionString, _settings.CommandTimeout, _settings.CollectIoStats,
-                _settings.CollectTimeStats, _settings.ForceDataRetrieval, _settings.KillQueriesOnCancel);
-
+                _settings.CollectTimeStats, _settings.ForceDataRetrieval);
             backgroundWorker1.RunWorkerAsync(engine);
 
             _start = new TimeSpan(DateTime.Now.Ticks);
@@ -479,11 +478,6 @@ namespace SQLQueryStress
             public bool ForceDataRetrieval;
 
             /// <summary>
-            ///     Cancel active SqlCommands on Cancel? (do not wait for completion)
-            /// </summary>
-            public bool KillQueriesOnCancel;
-
-            /// <summary>
             ///     Connection info for the DB in which to run the test
             /// </summary>
             public DatabaseSelect.ConnectionInfo MainDbConnectionInfo;
@@ -540,7 +534,6 @@ namespace SQLQueryStress
                 CollectIoStats = true;
                 CollectTimeStats = true;
                 ForceDataRetrieval = false;
-                KillQueriesOnCancel = true;
             }
 
             [OnDeserialized]

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -284,7 +284,8 @@ namespace SQLQueryStress
 
             var engine = new LoadEngine(_settings.MainDbConnectionInfo.ConnectionString, _settings.MainQuery, _settings.NumThreads, _settings.NumIterations,
                 _settings.ParamQuery, _settings.ParamMappings, paramConnectionInfo.ConnectionString, _settings.CommandTimeout, _settings.CollectIoStats,
-                _settings.CollectTimeStats, _settings.ForceDataRetrieval);
+                _settings.CollectTimeStats, _settings.ForceDataRetrieval, _settings.KillQueriesOnCancel);
+
             backgroundWorker1.RunWorkerAsync(engine);
 
             _start = new TimeSpan(DateTime.Now.Ticks);
@@ -478,6 +479,11 @@ namespace SQLQueryStress
             public bool ForceDataRetrieval;
 
             /// <summary>
+            ///     Cancel active SqlCommands on Cancel? (do not wait for completion)
+            /// </summary>
+            public bool KillQueriesOnCancel;
+
+            /// <summary>
             ///     Connection info for the DB in which to run the test
             /// </summary>
             public DatabaseSelect.ConnectionInfo MainDbConnectionInfo;
@@ -534,6 +540,7 @@ namespace SQLQueryStress
                 CollectIoStats = true;
                 CollectTimeStats = true;
                 ForceDataRetrieval = false;
+                KillQueriesOnCancel = true;
             }
 
             [OnDeserialized]

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -23,6 +23,7 @@ namespace SQLQueryStress
 
         private readonly string _connectionString;
         private readonly bool _forceDataRetrieval;
+        private readonly bool _killQueriesOnCancel;
         private readonly int _iterations;
         private readonly string _paramConnectionString;
         private readonly Dictionary<string, string> _paramMappings;
@@ -34,7 +35,7 @@ namespace SQLQueryStress
         private int _queryDelay;
 
         public LoadEngine(string connectionString, string query, int threads, int iterations, string paramQuery, Dictionary<string, string> paramMappings,
-            string paramConnectionString, int commandTimeout, bool collectIoStats, bool collectTimeStats, bool forceDataRetrieval)
+            string paramConnectionString, int commandTimeout, bool collectIoStats, bool collectTimeStats, bool forceDataRetrieval, bool killQueriesOnCancel)
         {
             //Set the min pool size so that the pool does not have
             //to get allocated in real-time
@@ -55,6 +56,7 @@ namespace SQLQueryStress
             _collectIoStats = collectIoStats;
             _collectTimeStats = collectTimeStats;
             _forceDataRetrieval = forceDataRetrieval;
+            _killQueriesOnCancel = killQueriesOnCancel;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities")]
@@ -142,7 +144,7 @@ namespace SQLQueryStress
 
                 var input = new QueryInput(statsComm, queryComm,
 //                    this.queryOutInfo,
-                    _iterations, _forceDataRetrieval, _queryDelay);
+                    _iterations, _forceDataRetrieval, _queryDelay, worker, _killQueriesOnCancel);
 
                 var theThread = new Thread(input.StartLoadThread) {Priority = ThreadPriority.BelowNormal};
 
@@ -347,14 +349,16 @@ namespace SQLQueryStress
             //private static Dictionary<int, List<string>> theInfoMessages = new Dictionary<int, List<string>>();
 
             private readonly Stopwatch _sw = new Stopwatch();
+            private System.Timers.Timer _killTimer = new System.Timers.Timer();
             private readonly bool _forceDataRetrieval;
             //          private readonly Queue<queryOutput> queryOutInfo;
             private readonly int _iterations;
             private readonly int _queryDelay;
+            private BackgroundWorker _backgroundWorker;
 
             public QueryInput(SqlCommand statsComm, SqlCommand queryComm,
 //                Queue<queryOutput> queryOutInfo,
-                int iterations, bool forceDataRetrieval, int queryDelay)
+                int iterations, bool forceDataRetrieval, int queryDelay, BackgroundWorker _backgroundWorker, bool killQueriesOnCancel)
             {
                 _statsComm = statsComm;
                 _queryComm = queryComm;
@@ -366,6 +370,24 @@ namespace SQLQueryStress
                 //Prepare the infoMessages collection, if we are collecting statistics
                 //if (stats_comm != null)
                 //    theInfoMessages.Add(stats_comm.Connection.GetHashCode(), new List<string>());
+
+                this._backgroundWorker = _backgroundWorker;
+
+                if (killQueriesOnCancel)
+                {
+                    _killTimer.Interval = 2000;
+                    _killTimer.Elapsed += _killTimer_Elapsed;
+                    _killTimer.Enabled = true;
+                }
+            }
+
+            private void _killTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+            {
+                if (_backgroundWorker.CancellationPending)
+                {
+                    _queryComm.Cancel();
+                    _killTimer.Enabled = false;
+                }
             }
 
             public static bool RunCancelled

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -387,7 +387,7 @@ namespace SQLQueryStress
                 {
                     _queryComm.Cancel();
                     _killTimer.Enabled = false;
-                } else if(_queryComm.Connection.State == ConnectionState.Closed)
+                } else if(_queryComm.Connection == null || _queryComm.Connection.State == ConnectionState.Closed)
                 {
                     _killTimer.Enabled = false;
                 }

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -387,6 +387,9 @@ namespace SQLQueryStress
                 {
                     _queryComm.Cancel();
                     _killTimer.Enabled = false;
+                } else if(_queryComm.Connection.State == ConnectionState.Closed)
+                {
+                    _killTimer.Enabled = false;
                 }
             }
 

--- a/src/SQLQueryStress/Options.Designer.cs
+++ b/src/SQLQueryStress/Options.Designer.cs
@@ -40,6 +40,7 @@ namespace SQLQueryStress
             this.connectionTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.commandTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
+            this.killQueriesOnCancel_checkBox = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.connectionTimeout_numericUpDown)).BeginInit();
             this.groupBox2.SuspendLayout();
@@ -113,7 +114,7 @@ namespace SQLQueryStress
             // ok_button
             // 
             this.ok_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ok_button.Location = new System.Drawing.Point(344, 145);
+            this.ok_button.Location = new System.Drawing.Point(344, 170);
             this.ok_button.Name = "ok_button";
             this.ok_button.Size = new System.Drawing.Size(75, 23);
             this.ok_button.TabIndex = 8;
@@ -125,7 +126,7 @@ namespace SQLQueryStress
             // 
             this.cancel_button.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancel_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cancel_button.Location = new System.Drawing.Point(425, 145);
+            this.cancel_button.Location = new System.Drawing.Point(425, 170);
             this.cancel_button.Name = "cancel_button";
             this.cancel_button.Size = new System.Drawing.Size(75, 23);
             this.cancel_button.TabIndex = 9;
@@ -140,7 +141,7 @@ namespace SQLQueryStress
             this.groupBox1.Controls.Add(this.connectionPooling_checkBox);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(241, 127);
+            this.groupBox1.Size = new System.Drawing.Size(241, 150);
             this.groupBox1.TabIndex = 10;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection Options";
@@ -169,6 +170,7 @@ namespace SQLQueryStress
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.killQueriesOnCancel_checkBox);
             this.groupBox2.Controls.Add(this.commandTimeout_numericUpDown);
             this.groupBox2.Controls.Add(this.label2);
             this.groupBox2.Controls.Add(this.IOStatistics_checkBox);
@@ -176,7 +178,7 @@ namespace SQLQueryStress
             this.groupBox2.Controls.Add(this.clientDataRetrieval_checkBox);
             this.groupBox2.Location = new System.Drawing.Point(259, 12);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(241, 127);
+            this.groupBox2.Size = new System.Drawing.Size(241, 150);
             this.groupBox2.TabIndex = 11;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Command Options";
@@ -194,13 +196,24 @@ namespace SQLQueryStress
             this.commandTimeout_numericUpDown.TabIndex = 8;
             this.commandTimeout_numericUpDown.Tag = "";
             // 
+            // killQueriesOnCancel_checkBox
+            // 
+            this.killQueriesOnCancel_checkBox.AutoSize = true;
+            this.killQueriesOnCancel_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.killQueriesOnCancel_checkBox.Location = new System.Drawing.Point(6, 127);
+            this.killQueriesOnCancel_checkBox.Name = "killQueriesOnCancel_checkBox";
+            this.killQueriesOnCancel_checkBox.Size = new System.Drawing.Size(151, 17);
+            this.killQueriesOnCancel_checkBox.TabIndex = 13;
+            this.killQueriesOnCancel_checkBox.Text = "Kill Queries on Cancel";
+            this.killQueriesOnCancel_checkBox.UseVisualStyleBackColor = true;
+            // 
             // Options
             // 
             this.AcceptButton = this.ok_button;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel_button;
-            this.ClientSize = new System.Drawing.Size(514, 178);
+            this.ClientSize = new System.Drawing.Size(514, 202);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.cancel_button);
@@ -237,5 +250,6 @@ namespace SQLQueryStress
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.NumericUpDown connectionTimeout_numericUpDown;
         private System.Windows.Forms.NumericUpDown commandTimeout_numericUpDown;
+        private System.Windows.Forms.CheckBox killQueriesOnCancel_checkBox;
     }
 }

--- a/src/SQLQueryStress/Options.Designer.cs
+++ b/src/SQLQueryStress/Options.Designer.cs
@@ -40,7 +40,6 @@ namespace SQLQueryStress
             this.connectionTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.commandTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
-            this.killQueriesOnCancel_checkBox = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.connectionTimeout_numericUpDown)).BeginInit();
             this.groupBox2.SuspendLayout();
@@ -114,7 +113,7 @@ namespace SQLQueryStress
             // ok_button
             // 
             this.ok_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ok_button.Location = new System.Drawing.Point(344, 170);
+            this.ok_button.Location = new System.Drawing.Point(344, 145);
             this.ok_button.Name = "ok_button";
             this.ok_button.Size = new System.Drawing.Size(75, 23);
             this.ok_button.TabIndex = 8;
@@ -126,7 +125,7 @@ namespace SQLQueryStress
             // 
             this.cancel_button.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancel_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cancel_button.Location = new System.Drawing.Point(425, 170);
+            this.cancel_button.Location = new System.Drawing.Point(425, 145);
             this.cancel_button.Name = "cancel_button";
             this.cancel_button.Size = new System.Drawing.Size(75, 23);
             this.cancel_button.TabIndex = 9;
@@ -141,7 +140,7 @@ namespace SQLQueryStress
             this.groupBox1.Controls.Add(this.connectionPooling_checkBox);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(241, 150);
+            this.groupBox1.Size = new System.Drawing.Size(241, 127);
             this.groupBox1.TabIndex = 10;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection Options";
@@ -170,7 +169,6 @@ namespace SQLQueryStress
             // 
             // groupBox2
             // 
-            this.groupBox2.Controls.Add(this.killQueriesOnCancel_checkBox);
             this.groupBox2.Controls.Add(this.commandTimeout_numericUpDown);
             this.groupBox2.Controls.Add(this.label2);
             this.groupBox2.Controls.Add(this.IOStatistics_checkBox);
@@ -178,7 +176,7 @@ namespace SQLQueryStress
             this.groupBox2.Controls.Add(this.clientDataRetrieval_checkBox);
             this.groupBox2.Location = new System.Drawing.Point(259, 12);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(241, 150);
+            this.groupBox2.Size = new System.Drawing.Size(241, 127);
             this.groupBox2.TabIndex = 11;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Command Options";
@@ -196,24 +194,13 @@ namespace SQLQueryStress
             this.commandTimeout_numericUpDown.TabIndex = 8;
             this.commandTimeout_numericUpDown.Tag = "";
             // 
-            // killQueriesOnCancel_checkBox
-            // 
-            this.killQueriesOnCancel_checkBox.AutoSize = true;
-            this.killQueriesOnCancel_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.killQueriesOnCancel_checkBox.Location = new System.Drawing.Point(6, 127);
-            this.killQueriesOnCancel_checkBox.Name = "killQueriesOnCancel_checkBox";
-            this.killQueriesOnCancel_checkBox.Size = new System.Drawing.Size(151, 17);
-            this.killQueriesOnCancel_checkBox.TabIndex = 13;
-            this.killQueriesOnCancel_checkBox.Text = "Kill Queries on Cancel";
-            this.killQueriesOnCancel_checkBox.UseVisualStyleBackColor = true;
-            // 
             // Options
             // 
             this.AcceptButton = this.ok_button;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel_button;
-            this.ClientSize = new System.Drawing.Size(514, 202);
+            this.ClientSize = new System.Drawing.Size(514, 178);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.cancel_button);
@@ -250,6 +237,5 @@ namespace SQLQueryStress
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.NumericUpDown connectionTimeout_numericUpDown;
         private System.Windows.Forms.NumericUpDown commandTimeout_numericUpDown;
-        private System.Windows.Forms.CheckBox killQueriesOnCancel_checkBox;
     }
 }

--- a/src/SQLQueryStress/Options.cs
+++ b/src/SQLQueryStress/Options.cs
@@ -23,7 +23,6 @@ namespace SQLQueryStress
             IOStatistics_checkBox.Checked = settings.CollectIoStats;
             timeStatistics_checkBox.Checked = settings.CollectTimeStats;
             clientDataRetrieval_checkBox.Checked = settings.ForceDataRetrieval;
-            killQueriesOnCancel_checkBox.Checked = settings.KillQueriesOnCancel;
         }
 
         private void cancel_button_Click(object sender, EventArgs e)
@@ -39,7 +38,6 @@ namespace SQLQueryStress
             _settings.CollectIoStats = IOStatistics_checkBox.Checked;
             _settings.CollectTimeStats = timeStatistics_checkBox.Checked;
             _settings.ForceDataRetrieval = clientDataRetrieval_checkBox.Checked;
-            _settings.KillQueriesOnCancel = killQueriesOnCancel_checkBox.Checked;
 
             Dispose();
         }

--- a/src/SQLQueryStress/Options.cs
+++ b/src/SQLQueryStress/Options.cs
@@ -23,6 +23,7 @@ namespace SQLQueryStress
             IOStatistics_checkBox.Checked = settings.CollectIoStats;
             timeStatistics_checkBox.Checked = settings.CollectTimeStats;
             clientDataRetrieval_checkBox.Checked = settings.ForceDataRetrieval;
+            killQueriesOnCancel_checkBox.Checked = settings.KillQueriesOnCancel;
         }
 
         private void cancel_button_Click(object sender, EventArgs e)
@@ -38,6 +39,7 @@ namespace SQLQueryStress
             _settings.CollectIoStats = IOStatistics_checkBox.Checked;
             _settings.CollectTimeStats = timeStatistics_checkBox.Checked;
             _settings.ForceDataRetrieval = clientDataRetrieval_checkBox.Checked;
+            _settings.KillQueriesOnCancel = killQueriesOnCancel_checkBox.Checked;
 
             Dispose();
         }

--- a/src/SQLQueryStress/Options.resx
+++ b/src/SQLQueryStress/Options.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/src/SQLQueryStress/Options.resx
+++ b/src/SQLQueryStress/Options.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
Thanks for the recommended process ErikEJ, I think I'm following along now. I've removed my old fork, forked from your master to get back to stable, done work in my KillQueriesOnCancel branch and are doing a Pull Request from that. I'm seeing five commits against your repository, but those are commits I did against my fork (one URL is https://github.com/ErikEJ/SqlQueryStress/commit/c05df7581249a0540644395142f12a7b83288c20) - are those an issue?

This pull request: Added option to kill active queries when Cancel button is pressed, enabled by default. I've done this by adding the Timer object "_killTimer" to LoadEngine.QueryInput, which (if the option has been enabled) checks for backgroundWorker having been given the cancel request, and if so, cancels the current Query, "KillQueriesOnCancel" flag to Form1 QueryStressSettings and  "Kill Queries on Cancel" checkbox to the Options dialog.