### PR TITLE
Improve support for keyboard navigation and prevent empty server name in "Database Select" dialog.

### DIFF
--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -74,7 +74,7 @@ namespace SQLQueryStress
             this.server_textBox.Location = new System.Drawing.Point(9, 55);
             this.server_textBox.Name = "server_textBox";
             this.server_textBox.Size = new System.Drawing.Size(231, 20);
-            this.server_textBox.TabIndex = 1;
+            this.server_textBox.TabIndex = 0;
             // 
             // authentication_comboBox
             // 
@@ -85,21 +85,21 @@ namespace SQLQueryStress
             this.authentication_comboBox.Location = new System.Drawing.Point(9, 94);
             this.authentication_comboBox.Name = "authentication_comboBox";
             this.authentication_comboBox.Size = new System.Drawing.Size(231, 21);
-            this.authentication_comboBox.TabIndex = 2;
+            this.authentication_comboBox.TabIndex = 1;
             // 
             // login_textBox
             // 
             this.login_textBox.Location = new System.Drawing.Point(9, 134);
             this.login_textBox.Name = "login_textBox";
             this.login_textBox.Size = new System.Drawing.Size(231, 20);
-            this.login_textBox.TabIndex = 3;
+            this.login_textBox.TabIndex = 2;
             // 
             // password_textBox
             // 
             this.password_textBox.Location = new System.Drawing.Point(9, 173);
             this.password_textBox.Name = "password_textBox";
             this.password_textBox.Size = new System.Drawing.Size(231, 20);
-            this.password_textBox.TabIndex = 4;
+            this.password_textBox.TabIndex = 3;
             this.password_textBox.UseSystemPasswordChar = true;
             // 
             // label2
@@ -139,7 +139,7 @@ namespace SQLQueryStress
             this.cancel_button.Location = new System.Drawing.Point(430, 286);
             this.cancel_button.Name = "cancel_button";
             this.cancel_button.Size = new System.Drawing.Size(80, 23);
-            this.cancel_button.TabIndex = 8;
+            this.cancel_button.TabIndex = 3;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
             this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
@@ -150,7 +150,7 @@ namespace SQLQueryStress
             this.test_button.Location = new System.Drawing.Point(120, 239);
             this.test_button.Name = "test_button";
             this.test_button.Size = new System.Drawing.Size(120, 23);
-            this.test_button.TabIndex = 9;
+            this.test_button.TabIndex = 5;
             this.test_button.Text = "Test Connection";
             this.test_button.UseVisualStyleBackColor = true;
             this.test_button.Click += new System.EventHandler(this.test_button_Click);
@@ -161,7 +161,7 @@ namespace SQLQueryStress
             this.ok_button.Location = new System.Drawing.Point(344, 286);
             this.ok_button.Name = "ok_button";
             this.ok_button.Size = new System.Drawing.Size(80, 23);
-            this.ok_button.TabIndex = 10;
+            this.ok_button.TabIndex = 2;
             this.ok_button.Text = "OK";
             this.ok_button.UseVisualStyleBackColor = true;
             this.ok_button.Click += new System.EventHandler(this.ok_button_Click);
@@ -172,7 +172,7 @@ namespace SQLQueryStress
             this.db_comboBox.Location = new System.Drawing.Point(9, 212);
             this.db_comboBox.Name = "db_comboBox";
             this.db_comboBox.Size = new System.Drawing.Size(231, 21);
-            this.db_comboBox.TabIndex = 11;
+            this.db_comboBox.TabIndex = 4;
             // 
             // label5
             // 
@@ -200,7 +200,7 @@ namespace SQLQueryStress
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(246, 268);
-            this.groupBox1.TabIndex = 13;
+            this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Main Load Settings";
             // 
@@ -221,7 +221,7 @@ namespace SQLQueryStress
             this.groupBox2.Location = new System.Drawing.Point(264, 12);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(246, 268);
-            this.groupBox2.TabIndex = 14;
+            this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Parameterization Settings";
             // 
@@ -232,7 +232,7 @@ namespace SQLQueryStress
             this.pm_test_button.Location = new System.Drawing.Point(123, 239);
             this.pm_test_button.Name = "pm_test_button";
             this.pm_test_button.Size = new System.Drawing.Size(120, 23);
-            this.pm_test_button.TabIndex = 15;
+            this.pm_test_button.TabIndex = 5;
             this.pm_test_button.Text = "Test Connection";
             this.pm_test_button.UseVisualStyleBackColor = true;
             this.pm_test_button.Click += new System.EventHandler(this.pm_test_button_Click);
@@ -258,7 +258,7 @@ namespace SQLQueryStress
             this.pm_db_comboBox.Location = new System.Drawing.Point(9, 212);
             this.pm_db_comboBox.Name = "pm_db_comboBox";
             this.pm_db_comboBox.Size = new System.Drawing.Size(231, 21);
-            this.pm_db_comboBox.TabIndex = 11;
+            this.pm_db_comboBox.TabIndex = 4;
             // 
             // label6
             // 
@@ -276,7 +276,7 @@ namespace SQLQueryStress
             this.pm_password_textBox.Location = new System.Drawing.Point(9, 173);
             this.pm_password_textBox.Name = "pm_password_textBox";
             this.pm_password_textBox.Size = new System.Drawing.Size(231, 20);
-            this.pm_password_textBox.TabIndex = 4;
+            this.pm_password_textBox.TabIndex = 3;
             this.pm_password_textBox.UseSystemPasswordChar = true;
             // 
             // label7
@@ -295,7 +295,7 @@ namespace SQLQueryStress
             this.pm_server_textBox.Location = new System.Drawing.Point(9, 55);
             this.pm_server_textBox.Name = "pm_server_textBox";
             this.pm_server_textBox.Size = new System.Drawing.Size(231, 20);
-            this.pm_server_textBox.TabIndex = 1;
+            this.pm_server_textBox.TabIndex = 0;
             // 
             // label8
             // 
@@ -323,7 +323,7 @@ namespace SQLQueryStress
             this.pm_login_textBox.Location = new System.Drawing.Point(9, 134);
             this.pm_login_textBox.Name = "pm_login_textBox";
             this.pm_login_textBox.Size = new System.Drawing.Size(231, 20);
-            this.pm_login_textBox.TabIndex = 3;
+            this.pm_login_textBox.TabIndex = 2;
             // 
             // pm_authentication_comboBox
             // 
@@ -335,7 +335,7 @@ namespace SQLQueryStress
             this.pm_authentication_comboBox.Location = new System.Drawing.Point(9, 94);
             this.pm_authentication_comboBox.Name = "pm_authentication_comboBox";
             this.pm_authentication_comboBox.Size = new System.Drawing.Size(231, 21);
-            this.pm_authentication_comboBox.TabIndex = 2;
+            this.pm_authentication_comboBox.TabIndex = 1;
             // 
             // label10
             // 

--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -168,6 +168,8 @@ namespace SQLQueryStress
             // 
             // db_comboBox
             // 
+            this.db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.db_comboBox.FormattingEnabled = true;
             this.db_comboBox.Location = new System.Drawing.Point(9, 212);
             this.db_comboBox.Name = "db_comboBox";
@@ -253,6 +255,8 @@ namespace SQLQueryStress
             // 
             // pm_db_comboBox
             // 
+            this.pm_db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.pm_db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.pm_db_comboBox.Enabled = false;
             this.pm_db_comboBox.FormattingEnabled = true;
             this.pm_db_comboBox.Location = new System.Drawing.Point(9, 212);

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -143,7 +143,7 @@ namespace SQLQueryStress
                 connectionString = _localParamConnectionInfo.ConnectionString;
             }
             
-                var sql = "SELECT name FROM master..sysdatabases ORDER BY name";
+                var sql = "SELECT databases.name FROM sys.databases WHERE databases.state = 0 ORDER BY databases.name";
 
                 using (var conn = new SqlConnection(connectionString))
                 {

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -98,14 +98,7 @@ namespace SQLQueryStress
 
         private void Server_textBox_TextChanged(object sender, EventArgs e)
         {
-            if (server_textBox.Text == string.Empty)
-            {
-                ok_button.Enabled = false;
-            }
-            else
-            {
-                ok_button.Enabled = true;
-            }
+            ok_button.Enabled = !string.IsNullOrEmpty(server_textBox.Text);
         }
 
         private void Server_textBox_KeyDown(object sender, KeyEventArgs e)
@@ -115,7 +108,7 @@ namespace SQLQueryStress
 
         private void Db_comboBox_Leave(object sender, EventArgs e)
         {
-            ComboBox cbSender = ((ComboBox)sender);
+            var cbSender = ((ComboBox)sender);
             if ((cbSender.SelectedValue == null || cbSender.Text != cbSender.SelectedItem.ToString()) && cbSender.Items.Contains(cbSender.Text))
             {
                 cbSender.SelectedItem = cbSender.Text;
@@ -124,8 +117,8 @@ namespace SQLQueryStress
 
         private void Db_comboBox_Enter(object sender, EventArgs e)
         {
-            ComboBox cbSender = ((ComboBox)sender);
-            string _prevSelectedValue = cbSender.SelectedValue != null ? cbSender.SelectedValue.ToString() : string.Empty;
+            var cbSender = ((ComboBox)sender);
+            var _prevSelectedValue = cbSender.SelectedValue != null ? cbSender.SelectedValue.ToString() : string.Empty;
             ReloadDatabaseList(sender);
 
             if (cbSender.Items.Contains(_prevSelectedValue))
@@ -136,8 +129,8 @@ namespace SQLQueryStress
 
         private void ReloadDatabaseList(object objDatabaseParam)
         {
-            ComboBox dbComboboxParam = (ComboBox)objDatabaseParam;
-            string selectedComboBoxItem = (string)dbComboboxParam.SelectedItem;
+            var dbComboboxParam = (ComboBox)objDatabaseParam;
+            var selectedComboBoxItem = (string)dbComboboxParam.SelectedItem;
             string connectionString;
             if (dbComboboxParam == db_comboBox)
             {
@@ -150,7 +143,7 @@ namespace SQLQueryStress
                 connectionString = _localParamConnectionInfo.ConnectionString;
             }
             
-                var sql = "" + "SELECT name " + "FROM master..sysdatabases " + "ORDER BY name";
+                var sql = "SELECT name FROM master..sysdatabases ORDER BY name";
 
                 using (var conn = new SqlConnection(connectionString))
                 {

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -224,52 +224,6 @@ namespace SQLQueryStress
             Dispose();
         }
 
-        private void db_comboBox_Click(object sender, EventArgs e)
-        {
-            SaveLocalSettings();
-
-            var selectedItem = (string) db_comboBox.SelectedItem;
-
-            var sql = "" + "SELECT name " + "FROM master..sysdatabases " + "ORDER BY name";
-
-            using (var conn = new SqlConnection(_localMainConnectionInfo.ConnectionString))
-            {
-                var comm = new SqlCommand(sql, conn);
-
-                var databases = new List<string>();
-
-                try
-                {
-                    conn.Open();
-
-                    var reader = comm.ExecuteReader();
-
-                    while (reader.Read())
-                    {
-                        databases.Add((string) reader[0]);
-                    }
-                }
-                catch (SqlException ex)
-                {
-                    if (ex.Number != 4060)
-                        MessageBox.Show(Resources.ConnFail);
-                    else
-                    {
-                        //Clear the db, try again
-                        db_comboBox.Items.Clear();
-                        db_comboBox_Click(null, null);
-                        return;
-                    }
-                }
-
-                db_comboBox.DataSource = databases.ToArray();
-
-                if (selectedItem != null)
-                    if (db_comboBox.Items.Contains(selectedItem))
-                        db_comboBox.SelectedItem = selectedItem;
-            }
-        }
-
         private void ok_button_Click(object sender, EventArgs e)
         {
             SaveLocalSettings();
@@ -293,50 +247,6 @@ namespace SQLQueryStress
             {
                 pm_login_textBox.Enabled = true;
                 pm_password_textBox.Enabled = true;
-            }
-        }
-
-        private void pm_db_comboBox_Click(object sender, EventArgs e)
-        {
-            pm_saveLocalSettings();
-
-            var selectedItem = (string) pm_db_comboBox.SelectedItem;
-
-            var sql = "" + "SELECT name " + "FROM master..sysdatabases " + "ORDER BY name";
-
-            using (var conn = new SqlConnection(_localParamConnectionInfo.ConnectionString))
-            {
-                var comm = new SqlCommand(sql, conn);
-
-                var databases = new List<string>();
-
-                try
-                {
-                    conn.Open();
-
-                    var reader = comm.ExecuteReader();
-
-                    while (reader.Read())
-                        databases.Add((string) reader[0]);
-                }
-                catch (SqlException ex)
-                {
-                    if (ex.Number != 4060)
-                        MessageBox.Show(Resources.ConnFail);
-                    else
-                    {
-                        //Clear the db, try again
-                        pm_db_comboBox.Items.Clear();
-                        pm_db_comboBox_Click(null, null);
-                        return;
-                    }
-                }
-
-                pm_db_comboBox.DataSource = databases.ToArray();
-
-                if (selectedItem != null)
-                    if (pm_db_comboBox.Items.Contains(selectedItem))
-                        pm_db_comboBox.SelectedItem = selectedItem;
             }
         }
 

--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -117,7 +117,7 @@ namespace SQLQueryStress
             this.label1.Location = new System.Drawing.Point(9, 32);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(40, 13);
-            this.label1.TabIndex = 1;
+            this.label1.TabIndex = 3;
             this.label1.Text = "Query";
             // 
             // menuStrip1
@@ -199,7 +199,7 @@ namespace SQLQueryStress
             this.go_button.Location = new System.Drawing.Point(3, 3);
             this.go_button.Name = "go_button";
             this.go_button.Size = new System.Drawing.Size(92, 40);
-            this.go_button.TabIndex = 3;
+            this.go_button.TabIndex = 0;
             this.go_button.Text = "GO";
             this.go_button.UseVisualStyleBackColor = true;
             this.go_button.Click += new System.EventHandler(this.go_button_Click);
@@ -242,7 +242,7 @@ namespace SQLQueryStress
             0});
             this.iterations_numericUpDown.Name = "iterations_numericUpDown";
             this.iterations_numericUpDown.Size = new System.Drawing.Size(196, 20);
-            this.iterations_numericUpDown.TabIndex = 8;
+            this.iterations_numericUpDown.TabIndex = 3;
             this.iterations_numericUpDown.Value = new decimal(new int[] {
             1,
             0,
@@ -265,7 +265,7 @@ namespace SQLQueryStress
             0});
             this.threads_numericUpDown.Name = "threads_numericUpDown";
             this.threads_numericUpDown.Size = new System.Drawing.Size(196, 20);
-            this.threads_numericUpDown.TabIndex = 9;
+            this.threads_numericUpDown.TabIndex = 4;
             this.threads_numericUpDown.Value = new decimal(new int[] {
             1,
             0,
@@ -280,7 +280,7 @@ namespace SQLQueryStress
             this.cancel_button.Location = new System.Drawing.Point(101, 3);
             this.cancel_button.Name = "cancel_button";
             this.cancel_button.Size = new System.Drawing.Size(92, 40);
-            this.cancel_button.TabIndex = 11;
+            this.cancel_button.TabIndex = 1;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
             this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
@@ -326,7 +326,7 @@ namespace SQLQueryStress
             this.avgSeconds_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.avgSeconds_textBox.Name = "avgSeconds_textBox";
             this.avgSeconds_textBox.Size = new System.Drawing.Size(196, 30);
-            this.avgSeconds_textBox.TabIndex = 13;
+            this.avgSeconds_textBox.TabIndex = 12;
             this.avgSeconds_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // progressBar1
@@ -337,7 +337,7 @@ namespace SQLQueryStress
             this.progressBar1.Name = "progressBar1";
             this.progressBar1.Size = new System.Drawing.Size(196, 30);
             this.progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-            this.progressBar1.TabIndex = 15;
+            this.progressBar1.TabIndex = 9;
             // 
             // label6
             // 
@@ -371,7 +371,7 @@ namespace SQLQueryStress
             this.totalExceptions_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.totalExceptions_textBox.Name = "totalExceptions_textBox";
             this.totalExceptions_textBox.Size = new System.Drawing.Size(155, 30);
-            this.totalExceptions_textBox.TabIndex = 17;
+            this.totalExceptions_textBox.TabIndex = 1;
             this.totalExceptions_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.totalExceptions_textBox.Click += new System.EventHandler(this.totalExceptions_textBox_Click);
             // 
@@ -401,7 +401,7 @@ namespace SQLQueryStress
             this.elapsedTime_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.elapsedTime_textBox.Name = "elapsedTime_textBox";
             this.elapsedTime_textBox.Size = new System.Drawing.Size(196, 30);
-            this.elapsedTime_textBox.TabIndex = 19;
+            this.elapsedTime_textBox.TabIndex = 10;
             this.elapsedTime_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // perfCounterTimer
@@ -415,7 +415,7 @@ namespace SQLQueryStress
             this.database_button.Location = new System.Drawing.Point(3, 69);
             this.database_button.Name = "database_button";
             this.database_button.Size = new System.Drawing.Size(196, 30);
-            this.database_button.TabIndex = 22;
+            this.database_button.TabIndex = 1;
             this.database_button.Text = "Database";
             this.database_button.UseVisualStyleBackColor = true;
             this.database_button.Click += new System.EventHandler(this.database_button_Click);
@@ -431,7 +431,7 @@ namespace SQLQueryStress
             this.iterationsSecond_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.iterationsSecond_textBox.Name = "iterationsSecond_textBox";
             this.iterationsSecond_textBox.Size = new System.Drawing.Size(196, 30);
-            this.iterationsSecond_textBox.TabIndex = 23;
+            this.iterationsSecond_textBox.TabIndex = 11;
             this.iterationsSecond_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // exceptions_button
@@ -440,7 +440,7 @@ namespace SQLQueryStress
             this.exceptions_button.Location = new System.Drawing.Point(164, 3);
             this.exceptions_button.Name = "exceptions_button";
             this.exceptions_button.Size = new System.Drawing.Size(27, 23);
-            this.exceptions_button.TabIndex = 24;
+            this.exceptions_button.TabIndex = 1;
             this.exceptions_button.Text = "...";
             this.exceptions_button.UseVisualStyleBackColor = true;
             this.exceptions_button.Click += new System.EventHandler(this.exceptions_button_Click);
@@ -467,7 +467,7 @@ namespace SQLQueryStress
             this.cpuTime_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.cpuTime_textBox.Name = "cpuTime_textBox";
             this.cpuTime_textBox.Size = new System.Drawing.Size(196, 30);
-            this.cpuTime_textBox.TabIndex = 25;
+            this.cpuTime_textBox.TabIndex = 6;
             this.cpuTime_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label12
@@ -492,7 +492,7 @@ namespace SQLQueryStress
             this.logicalReads_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.logicalReads_textBox.Name = "logicalReads_textBox";
             this.logicalReads_textBox.Size = new System.Drawing.Size(196, 30);
-            this.logicalReads_textBox.TabIndex = 29;
+            this.logicalReads_textBox.TabIndex = 14;
             this.logicalReads_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // db_label
@@ -502,7 +502,7 @@ namespace SQLQueryStress
             this.db_label.Location = new System.Drawing.Point(55, 32);
             this.db_label.Name = "db_label";
             this.db_label.Size = new System.Drawing.Size(0, 13);
-            this.db_label.TabIndex = 31;
+            this.db_label.TabIndex = 1;
             // 
             // tableLayoutPanel1
             // 
@@ -554,7 +554,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(404, 404);
-            this.tableLayoutPanel1.TabIndex = 32;
+            this.tableLayoutPanel1.TabIndex = 1;
             // 
             // label10
             // 
@@ -575,7 +575,7 @@ namespace SQLQueryStress
             this.flowLayoutPanel1.Location = new System.Drawing.Point(205, 269);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(196, 30);
-            this.flowLayoutPanel1.TabIndex = 31;
+            this.flowLayoutPanel1.TabIndex = 13;
             // 
             // actualSeconds_textBox
             // 
@@ -588,7 +588,7 @@ namespace SQLQueryStress
             this.actualSeconds_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.actualSeconds_textBox.Name = "actualSeconds_textBox";
             this.actualSeconds_textBox.Size = new System.Drawing.Size(196, 26);
-            this.actualSeconds_textBox.TabIndex = 27;
+            this.actualSeconds_textBox.TabIndex = 7;
             this.actualSeconds_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // tableLayoutPanel2
@@ -604,7 +604,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel2.Size = new System.Drawing.Size(196, 46);
-            this.tableLayoutPanel2.TabIndex = 32;
+            this.tableLayoutPanel2.TabIndex = 8;
             // 
             // param_button
             // 
@@ -613,7 +613,7 @@ namespace SQLQueryStress
             this.param_button.Location = new System.Drawing.Point(3, 119);
             this.param_button.Name = "param_button";
             this.param_button.Size = new System.Drawing.Size(196, 30);
-            this.param_button.TabIndex = 21;
+            this.param_button.TabIndex = 2;
             this.param_button.Text = "Parameter Substitution";
             this.param_button.UseVisualStyleBackColor = true;
             this.param_button.Click += new System.EventHandler(this.param_button_Click);
@@ -632,7 +632,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel4.Size = new System.Drawing.Size(196, 46);
-            this.tableLayoutPanel4.TabIndex = 33;
+            this.tableLayoutPanel4.TabIndex = 0;
             // 
             // btnFreeCache
             // 
@@ -675,7 +675,7 @@ namespace SQLQueryStress
             this.queryDelay_textBox.Location = new System.Drawing.Point(3, 269);
             this.queryDelay_textBox.Name = "queryDelay_textBox";
             this.queryDelay_textBox.Size = new System.Drawing.Size(196, 20);
-            this.queryDelay_textBox.TabIndex = 35;
+            this.queryDelay_textBox.TabIndex = 5;
             this.queryDelay_textBox.Text = "0";
             // 
             // tableLayoutPanel3
@@ -691,7 +691,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(741, 410);
-            this.tableLayoutPanel3.TabIndex = 33;
+            this.tableLayoutPanel3.TabIndex = 2;
             // 
             // elementHost1
             // 
@@ -699,7 +699,7 @@ namespace SQLQueryStress
             this.elementHost1.Location = new System.Drawing.Point(3, 3);
             this.elementHost1.Name = "elementHost1";
             this.elementHost1.Size = new System.Drawing.Size(325, 404);
-            this.elementHost1.TabIndex = 33;
+            this.elementHost1.TabIndex = 0;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
             // 
@@ -781,12 +781,12 @@ namespace SQLQueryStress
         private TableLayoutPanel tableLayoutPanel4;
         private Button btnFreeCache;
         private Button btnCleanBuffer;
-        private System.Windows.Forms.Integration.ElementHost elementHost1;
-        private SqlControl sqlControl1;
         private Label actualSeconds_textBox;
         private Label label10;
         private Label label11;
         private TextBox queryDelay_textBox;
+        private System.Windows.Forms.Integration.ElementHost elementHost1;
+        private SqlControl sqlControl1;
     }
 }
 

--- a/src/SQLQueryStress/Options.Designer.cs
+++ b/src/SQLQueryStress/Options.Designer.cs
@@ -39,8 +39,8 @@ namespace SQLQueryStress
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.connectionTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.commandTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.killQueriesOnCancel_checkBox = new System.Windows.Forms.CheckBox();
+            this.commandTimeout_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.connectionTimeout_numericUpDown)).BeginInit();
             this.groupBox2.SuspendLayout();
@@ -54,7 +54,7 @@ namespace SQLQueryStress
             this.IOStatistics_checkBox.Location = new System.Drawing.Point(6, 58);
             this.IOStatistics_checkBox.Name = "IOStatistics_checkBox";
             this.IOStatistics_checkBox.Size = new System.Drawing.Size(144, 17);
-            this.IOStatistics_checkBox.TabIndex = 0;
+            this.IOStatistics_checkBox.TabIndex = 1;
             this.IOStatistics_checkBox.Text = "Collect I/O Statistics";
             this.IOStatistics_checkBox.UseVisualStyleBackColor = true;
             // 
@@ -65,7 +65,7 @@ namespace SQLQueryStress
             this.timeStatistics_checkBox.Location = new System.Drawing.Point(6, 81);
             this.timeStatistics_checkBox.Name = "timeStatistics_checkBox";
             this.timeStatistics_checkBox.Size = new System.Drawing.Size(152, 17);
-            this.timeStatistics_checkBox.TabIndex = 1;
+            this.timeStatistics_checkBox.TabIndex = 2;
             this.timeStatistics_checkBox.Text = "Collect Time Statistics";
             this.timeStatistics_checkBox.UseVisualStyleBackColor = true;
             // 
@@ -96,7 +96,7 @@ namespace SQLQueryStress
             this.connectionPooling_checkBox.Location = new System.Drawing.Point(6, 58);
             this.connectionPooling_checkBox.Name = "connectionPooling_checkBox";
             this.connectionPooling_checkBox.Size = new System.Drawing.Size(179, 17);
-            this.connectionPooling_checkBox.TabIndex = 6;
+            this.connectionPooling_checkBox.TabIndex = 1;
             this.connectionPooling_checkBox.Text = "Enable Connection Pooling";
             this.connectionPooling_checkBox.UseVisualStyleBackColor = true;
             // 
@@ -107,7 +107,7 @@ namespace SQLQueryStress
             this.clientDataRetrieval_checkBox.Location = new System.Drawing.Point(6, 104);
             this.clientDataRetrieval_checkBox.Name = "clientDataRetrieval_checkBox";
             this.clientDataRetrieval_checkBox.Size = new System.Drawing.Size(195, 17);
-            this.clientDataRetrieval_checkBox.TabIndex = 7;
+            this.clientDataRetrieval_checkBox.TabIndex = 3;
             this.clientDataRetrieval_checkBox.Text = "Force Client Retrieval of Data";
             this.clientDataRetrieval_checkBox.UseVisualStyleBackColor = true;
             // 
@@ -117,7 +117,7 @@ namespace SQLQueryStress
             this.ok_button.Location = new System.Drawing.Point(344, 170);
             this.ok_button.Name = "ok_button";
             this.ok_button.Size = new System.Drawing.Size(75, 23);
-            this.ok_button.TabIndex = 8;
+            this.ok_button.TabIndex = 2;
             this.ok_button.Text = "OK";
             this.ok_button.UseVisualStyleBackColor = true;
             this.ok_button.Click += new System.EventHandler(this.ok_button_Click);
@@ -129,7 +129,7 @@ namespace SQLQueryStress
             this.cancel_button.Location = new System.Drawing.Point(425, 170);
             this.cancel_button.Name = "cancel_button";
             this.cancel_button.Size = new System.Drawing.Size(75, 23);
-            this.cancel_button.TabIndex = 9;
+            this.cancel_button.TabIndex = 3;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
             this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
@@ -142,7 +142,7 @@ namespace SQLQueryStress
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(241, 150);
-            this.groupBox1.TabIndex = 10;
+            this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection Options";
             // 
@@ -161,7 +161,7 @@ namespace SQLQueryStress
             0});
             this.connectionTimeout_numericUpDown.Name = "connectionTimeout_numericUpDown";
             this.connectionTimeout_numericUpDown.Size = new System.Drawing.Size(120, 20);
-            this.connectionTimeout_numericUpDown.TabIndex = 7;
+            this.connectionTimeout_numericUpDown.TabIndex = 0;
             this.connectionTimeout_numericUpDown.Value = new decimal(new int[] {
             1,
             0,
@@ -179,9 +179,20 @@ namespace SQLQueryStress
             this.groupBox2.Location = new System.Drawing.Point(259, 12);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(241, 150);
-            this.groupBox2.TabIndex = 11;
+            this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Command Options";
+            // 
+            // killQueriesOnCancel_checkBox
+            // 
+            this.killQueriesOnCancel_checkBox.AutoSize = true;
+            this.killQueriesOnCancel_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.killQueriesOnCancel_checkBox.Location = new System.Drawing.Point(6, 127);
+            this.killQueriesOnCancel_checkBox.Name = "killQueriesOnCancel_checkBox";
+            this.killQueriesOnCancel_checkBox.Size = new System.Drawing.Size(151, 17);
+            this.killQueriesOnCancel_checkBox.TabIndex = 4;
+            this.killQueriesOnCancel_checkBox.Text = "Kill Queries on Cancel";
+            this.killQueriesOnCancel_checkBox.UseVisualStyleBackColor = true;
             // 
             // commandTimeout_numericUpDown
             // 
@@ -193,19 +204,8 @@ namespace SQLQueryStress
             0});
             this.commandTimeout_numericUpDown.Name = "commandTimeout_numericUpDown";
             this.commandTimeout_numericUpDown.Size = new System.Drawing.Size(120, 20);
-            this.commandTimeout_numericUpDown.TabIndex = 8;
+            this.commandTimeout_numericUpDown.TabIndex = 0;
             this.commandTimeout_numericUpDown.Tag = "";
-            // 
-            // killQueriesOnCancel_checkBox
-            // 
-            this.killQueriesOnCancel_checkBox.AutoSize = true;
-            this.killQueriesOnCancel_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.killQueriesOnCancel_checkBox.Location = new System.Drawing.Point(6, 127);
-            this.killQueriesOnCancel_checkBox.Name = "killQueriesOnCancel_checkBox";
-            this.killQueriesOnCancel_checkBox.Size = new System.Drawing.Size(151, 17);
-            this.killQueriesOnCancel_checkBox.TabIndex = 13;
-            this.killQueriesOnCancel_checkBox.Text = "Kill Queries on Cancel";
-            this.killQueriesOnCancel_checkBox.UseVisualStyleBackColor = true;
             // 
             // Options
             // 

--- a/src/SQLQueryStress/ParamWindow.Designer.cs
+++ b/src/SQLQueryStress/ParamWindow.Designer.cs
@@ -56,7 +56,7 @@ namespace SQLQueryStress
             this.columnMapGrid.Name = "columnMapGrid";
             this.columnMapGrid.ShowEditingIcon = false;
             this.columnMapGrid.Size = new System.Drawing.Size(435, 185);
-            this.columnMapGrid.TabIndex = 0;
+            this.columnMapGrid.TabIndex = 3;
             // 
             // Column
             // 
@@ -92,7 +92,7 @@ namespace SQLQueryStress
             this.getColumnsButton.Location = new System.Drawing.Point(15, 219);
             this.getColumnsButton.Name = "getColumnsButton";
             this.getColumnsButton.Size = new System.Drawing.Size(98, 23);
-            this.getColumnsButton.TabIndex = 3;
+            this.getColumnsButton.TabIndex = 1;
             this.getColumnsButton.Text = "Get Columns";
             this.getColumnsButton.UseVisualStyleBackColor = true;
             this.getColumnsButton.Click += new System.EventHandler(this.getColumnsButton_Click);
@@ -136,7 +136,7 @@ namespace SQLQueryStress
             this.database_button.Location = new System.Drawing.Point(119, 219);
             this.database_button.Name = "database_button";
             this.database_button.Size = new System.Drawing.Size(94, 23);
-            this.database_button.TabIndex = 7;
+            this.database_button.TabIndex = 2;
             this.database_button.Text = "Database";
             this.database_button.UseVisualStyleBackColor = true;
             this.database_button.Click += new System.EventHandler(this.database_button_Click);
@@ -146,7 +146,7 @@ namespace SQLQueryStress
             this.elementHost1.Location = new System.Drawing.Point(15, 36);
             this.elementHost1.Name = "elementHost1";
             this.elementHost1.Size = new System.Drawing.Size(432, 177);
-            this.elementHost1.TabIndex = 8;
+            this.elementHost1.TabIndex = 0;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
             // 


### PR DESCRIPTION
Modified both Default Database drop-downs on "Database Select" dialog to reload on enter instead of on drop-down to improve keyboard navigation.
Enabled auto-complete on both Default Database drop-downs on "Database Select" dialog to improve keyboard navigation.
Modified tab order on Form1, DatabaseSelect, Options and ParamWindow to improve keyboard navigation.
Modified "Database Select" dialog to disable OK button when Server Name is empty.