### PR TITLE
Make param window resizable

### DIFF
--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -55,8 +55,8 @@ namespace SQLQueryStress
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveBenchMarkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.go_button = new System.Windows.Forms.Button();
@@ -115,10 +115,9 @@ namespace SQLQueryStress
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(14, 49);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(9, 32);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(59, 20);
+            this.label1.Size = new System.Drawing.Size(40, 13);
             this.label1.TabIndex = 3;
             this.label1.Text = "Query";
             // 
@@ -131,8 +130,7 @@ namespace SQLQueryStress
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
-            this.menuStrip1.Size = new System.Drawing.Size(1112, 35);
+            this.menuStrip1.Size = new System.Drawing.Size(741, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -146,61 +144,61 @@ namespace SQLQueryStress
             this.saveBenchMarkToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(222, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(158, 6);
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.optionsToolStripMenuItem.Text = "Options";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // saveSettingsToolStripMenuItem
             // 
             this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
-            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
+            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.saveSettingsToolStripMenuItem.Text = "Save Settings";
             this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
             // 
             // loadSettingsToolStripMenuItem
             // 
             this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
-            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.loadSettingsToolStripMenuItem.Text = "Load Settings";
             this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
-            // 
-            // exitToolStripMenuItem
-            // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
-            this.exitToolStripMenuItem.Text = "Exit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
             // saveBenchMarkToolStripMenuItem
             // 
             this.saveBenchMarkToolStripMenuItem.Name = "saveBenchMarkToolStripMenuItem";
-            this.saveBenchMarkToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
+            this.saveBenchMarkToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.saveBenchMarkToolStripMenuItem.Text = "Save BenchMark";
             this.saveBenchMarkToolStripMenuItem.Click += new System.EventHandler(this.saveBenchMarkToolStripMenuItem_Click);
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.exitToolStripMenuItem.Text = "Exit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(146, 30);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -208,10 +206,9 @@ namespace SQLQueryStress
             // 
             this.go_button.Dock = System.Windows.Forms.DockStyle.Fill;
             this.go_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.go_button.Location = new System.Drawing.Point(4, 5);
-            this.go_button.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.go_button.Location = new System.Drawing.Point(3, 3);
             this.go_button.Name = "go_button";
-            this.go_button.Size = new System.Drawing.Size(139, 60);
+            this.go_button.Size = new System.Drawing.Size(92, 40);
             this.go_button.TabIndex = 0;
             this.go_button.Text = "GO";
             this.go_button.UseVisualStyleBackColor = true;
@@ -222,10 +219,9 @@ namespace SQLQueryStress
             this.label2.AutoSize = true;
             this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(4, 234);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(3, 152);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(295, 22);
+            this.label2.Size = new System.Drawing.Size(196, 14);
             this.label2.TabIndex = 5;
             this.label2.Text = "Number of Iterations";
             // 
@@ -234,18 +230,16 @@ namespace SQLQueryStress
             this.label3.AutoSize = true;
             this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(4, 311);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(3, 202);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(295, 22);
+            this.label3.Size = new System.Drawing.Size(196, 14);
             this.label3.TabIndex = 7;
             this.label3.Text = "Number of Threads";
             // 
             // iterations_numericUpDown
             // 
             this.iterations_numericUpDown.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.iterations_numericUpDown.Location = new System.Drawing.Point(4, 261);
-            this.iterations_numericUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.iterations_numericUpDown.Location = new System.Drawing.Point(3, 169);
             this.iterations_numericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
@@ -257,7 +251,7 @@ namespace SQLQueryStress
             0,
             0});
             this.iterations_numericUpDown.Name = "iterations_numericUpDown";
-            this.iterations_numericUpDown.Size = new System.Drawing.Size(294, 26);
+            this.iterations_numericUpDown.Size = new System.Drawing.Size(196, 20);
             this.iterations_numericUpDown.TabIndex = 3;
             this.iterations_numericUpDown.Value = new decimal(new int[] {
             1,
@@ -268,8 +262,7 @@ namespace SQLQueryStress
             // threads_numericUpDown
             // 
             this.threads_numericUpDown.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.threads_numericUpDown.Location = new System.Drawing.Point(4, 338);
-            this.threads_numericUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.threads_numericUpDown.Location = new System.Drawing.Point(3, 219);
             this.threads_numericUpDown.Maximum = new decimal(new int[] {
             200,
             0,
@@ -281,7 +274,7 @@ namespace SQLQueryStress
             0,
             0});
             this.threads_numericUpDown.Name = "threads_numericUpDown";
-            this.threads_numericUpDown.Size = new System.Drawing.Size(294, 26);
+            this.threads_numericUpDown.Size = new System.Drawing.Size(196, 20);
             this.threads_numericUpDown.TabIndex = 4;
             this.threads_numericUpDown.Value = new decimal(new int[] {
             1,
@@ -294,10 +287,9 @@ namespace SQLQueryStress
             this.cancel_button.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cancel_button.Enabled = false;
             this.cancel_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cancel_button.Location = new System.Drawing.Point(151, 5);
-            this.cancel_button.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cancel_button.Location = new System.Drawing.Point(101, 3);
             this.cancel_button.Name = "cancel_button";
-            this.cancel_button.Size = new System.Drawing.Size(140, 60);
+            this.cancel_button.Size = new System.Drawing.Size(92, 40);
             this.cancel_button.TabIndex = 1;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
@@ -308,10 +300,9 @@ namespace SQLQueryStress
             this.label4.AutoSize = true;
             this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(307, 234);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(205, 152);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(295, 22);
+            this.label4.Size = new System.Drawing.Size(196, 14);
             this.label4.TabIndex = 12;
             this.label4.Text = "Iterations Completed";
             // 
@@ -328,10 +319,9 @@ namespace SQLQueryStress
             this.label5.AutoSize = true;
             this.label5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(307, 311);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Location = new System.Drawing.Point(205, 202);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(295, 22);
+            this.label5.Size = new System.Drawing.Size(196, 14);
             this.label5.TabIndex = 14;
             this.label5.Text = "Client Seconds/Iteration (Avg)";
             // 
@@ -342,10 +332,10 @@ namespace SQLQueryStress
             this.avgSeconds_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.avgSeconds_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.avgSeconds_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.avgSeconds_textBox.Location = new System.Drawing.Point(307, 338);
-            this.avgSeconds_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.avgSeconds_textBox.Location = new System.Drawing.Point(205, 219);
+            this.avgSeconds_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.avgSeconds_textBox.Name = "avgSeconds_textBox";
-            this.avgSeconds_textBox.Size = new System.Drawing.Size(295, 45);
+            this.avgSeconds_textBox.Size = new System.Drawing.Size(196, 30);
             this.avgSeconds_textBox.TabIndex = 12;
             this.avgSeconds_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -353,10 +343,9 @@ namespace SQLQueryStress
             // 
             this.progressBar1.BackColor = System.Drawing.SystemColors.Control;
             this.progressBar1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.progressBar1.Location = new System.Drawing.Point(307, 107);
-            this.progressBar1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.progressBar1.Location = new System.Drawing.Point(205, 69);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(295, 45);
+            this.progressBar1.Size = new System.Drawing.Size(196, 30);
             this.progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.progressBar1.TabIndex = 9;
             // 
@@ -365,10 +354,9 @@ namespace SQLQueryStress
             this.label6.AutoSize = true;
             this.label6.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(307, 80);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Location = new System.Drawing.Point(205, 52);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(295, 22);
+            this.label6.Size = new System.Drawing.Size(196, 14);
             this.label6.TabIndex = 16;
             this.label6.Text = "Progress";
             // 
@@ -377,10 +365,9 @@ namespace SQLQueryStress
             this.label7.AutoSize = true;
             this.label7.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(307, 388);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Location = new System.Drawing.Point(205, 252);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(295, 22);
+            this.label7.Size = new System.Drawing.Size(196, 14);
             this.label7.TabIndex = 18;
             this.label7.Text = "Total Exceptions";
             // 
@@ -390,10 +377,10 @@ namespace SQLQueryStress
             this.totalExceptions_textBox.Cursor = System.Windows.Forms.Cursors.Default;
             this.totalExceptions_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.totalExceptions_textBox.ForeColor = System.Drawing.Color.Red;
-            this.totalExceptions_textBox.Location = new System.Drawing.Point(4, 5);
-            this.totalExceptions_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.totalExceptions_textBox.Location = new System.Drawing.Point(3, 3);
+            this.totalExceptions_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.totalExceptions_textBox.Name = "totalExceptions_textBox";
-            this.totalExceptions_textBox.Size = new System.Drawing.Size(232, 46);
+            this.totalExceptions_textBox.Size = new System.Drawing.Size(155, 30);
             this.totalExceptions_textBox.TabIndex = 1;
             this.totalExceptions_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.totalExceptions_textBox.Click += new System.EventHandler(this.totalExceptions_textBox_Click);
@@ -407,10 +394,9 @@ namespace SQLQueryStress
             this.label8.AutoSize = true;
             this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(307, 157);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.Location = new System.Drawing.Point(205, 102);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(295, 22);
+            this.label8.Size = new System.Drawing.Size(196, 14);
             this.label8.TabIndex = 20;
             this.label8.Text = "Elapsed Time";
             // 
@@ -421,10 +407,10 @@ namespace SQLQueryStress
             this.elapsedTime_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.elapsedTime_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.elapsedTime_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.elapsedTime_textBox.Location = new System.Drawing.Point(307, 184);
-            this.elapsedTime_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.elapsedTime_textBox.Location = new System.Drawing.Point(205, 119);
+            this.elapsedTime_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.elapsedTime_textBox.Name = "elapsedTime_textBox";
-            this.elapsedTime_textBox.Size = new System.Drawing.Size(295, 45);
+            this.elapsedTime_textBox.Size = new System.Drawing.Size(196, 30);
             this.elapsedTime_textBox.TabIndex = 10;
             this.elapsedTime_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -436,10 +422,9 @@ namespace SQLQueryStress
             // 
             this.database_button.Dock = System.Windows.Forms.DockStyle.Fill;
             this.database_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.database_button.Location = new System.Drawing.Point(4, 107);
-            this.database_button.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.database_button.Location = new System.Drawing.Point(3, 69);
             this.database_button.Name = "database_button";
-            this.database_button.Size = new System.Drawing.Size(295, 45);
+            this.database_button.Size = new System.Drawing.Size(196, 30);
             this.database_button.TabIndex = 1;
             this.database_button.Text = "Database";
             this.database_button.UseVisualStyleBackColor = true;
@@ -452,20 +437,19 @@ namespace SQLQueryStress
             this.iterationsSecond_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.iterationsSecond_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.iterationsSecond_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.iterationsSecond_textBox.Location = new System.Drawing.Point(307, 261);
-            this.iterationsSecond_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.iterationsSecond_textBox.Location = new System.Drawing.Point(205, 169);
+            this.iterationsSecond_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.iterationsSecond_textBox.Name = "iterationsSecond_textBox";
-            this.iterationsSecond_textBox.Size = new System.Drawing.Size(295, 45);
+            this.iterationsSecond_textBox.Size = new System.Drawing.Size(196, 30);
             this.iterationsSecond_textBox.TabIndex = 11;
             this.iterationsSecond_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // exceptions_button
             // 
             this.exceptions_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.exceptions_button.Location = new System.Drawing.Point(244, 5);
-            this.exceptions_button.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.exceptions_button.Location = new System.Drawing.Point(164, 3);
             this.exceptions_button.Name = "exceptions_button";
-            this.exceptions_button.Size = new System.Drawing.Size(40, 35);
+            this.exceptions_button.Size = new System.Drawing.Size(27, 23);
             this.exceptions_button.TabIndex = 1;
             this.exceptions_button.Text = "...";
             this.exceptions_button.UseVisualStyleBackColor = true;
@@ -476,10 +460,9 @@ namespace SQLQueryStress
             this.label9.AutoSize = true;
             this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(4, 465);
-            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label9.Location = new System.Drawing.Point(3, 302);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(295, 22);
+            this.label9.Size = new System.Drawing.Size(196, 14);
             this.label9.TabIndex = 26;
             this.label9.Text = "CPU Seconds/Iteration (Avg)";
             // 
@@ -490,10 +473,10 @@ namespace SQLQueryStress
             this.cpuTime_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cpuTime_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cpuTime_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.cpuTime_textBox.Location = new System.Drawing.Point(4, 492);
-            this.cpuTime_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cpuTime_textBox.Location = new System.Drawing.Point(3, 319);
+            this.cpuTime_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.cpuTime_textBox.Name = "cpuTime_textBox";
-            this.cpuTime_textBox.Size = new System.Drawing.Size(295, 45);
+            this.cpuTime_textBox.Size = new System.Drawing.Size(196, 30);
             this.cpuTime_textBox.TabIndex = 6;
             this.cpuTime_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -502,10 +485,9 @@ namespace SQLQueryStress
             this.label12.AutoSize = true;
             this.label12.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label12.Location = new System.Drawing.Point(307, 465);
-            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label12.Location = new System.Drawing.Point(205, 302);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(295, 22);
+            this.label12.Size = new System.Drawing.Size(196, 14);
             this.label12.TabIndex = 30;
             this.label12.Text = "Logical Reads/Iteration (Avg)";
             // 
@@ -516,10 +498,10 @@ namespace SQLQueryStress
             this.logicalReads_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.logicalReads_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.logicalReads_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.logicalReads_textBox.Location = new System.Drawing.Point(307, 492);
-            this.logicalReads_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.logicalReads_textBox.Location = new System.Drawing.Point(205, 319);
+            this.logicalReads_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.logicalReads_textBox.Name = "logicalReads_textBox";
-            this.logicalReads_textBox.Size = new System.Drawing.Size(295, 45);
+            this.logicalReads_textBox.Size = new System.Drawing.Size(196, 30);
             this.logicalReads_textBox.TabIndex = 14;
             this.logicalReads_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -527,17 +509,16 @@ namespace SQLQueryStress
             // 
             this.db_label.AutoSize = true;
             this.db_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.db_label.Location = new System.Drawing.Point(82, 49);
-            this.db_label.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.db_label.Location = new System.Drawing.Point(55, 32);
             this.db_label.Name = "db_label";
-            this.db_label.Size = new System.Drawing.Size(0, 20);
+            this.db_label.Size = new System.Drawing.Size(0, 13);
             this.db_label.TabIndex = 1;
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 303F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 303F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 202F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 202F));
             this.tableLayoutPanel1.Controls.Add(this.logicalReads_textBox, 1, 12);
             this.tableLayoutPanel1.Controls.Add(this.label12, 1, 11);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 5);
@@ -564,26 +545,25 @@ namespace SQLQueryStress
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 9);
             this.tableLayoutPanel1.Controls.Add(this.queryDelay_textBox, 0, 10);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(502, 5);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(334, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 15;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 80F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 52F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(606, 622);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(404, 404);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
             // label10
@@ -591,10 +571,9 @@ namespace SQLQueryStress
             this.label10.AutoSize = true;
             this.label10.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label10.Location = new System.Drawing.Point(4, 542);
-            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label10.Location = new System.Drawing.Point(3, 352);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(295, 31);
+            this.label10.Size = new System.Drawing.Size(196, 20);
             this.label10.TabIndex = 28;
             this.label10.Text = "Actual Seconds/Iteration (Avg)";
             // 
@@ -603,10 +582,9 @@ namespace SQLQueryStress
             this.flowLayoutPanel1.Controls.Add(this.totalExceptions_textBox);
             this.flowLayoutPanel1.Controls.Add(this.exceptions_button);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(307, 415);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(205, 269);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(295, 45);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(196, 30);
             this.flowLayoutPanel1.TabIndex = 13;
             // 
             // actualSeconds_textBox
@@ -616,10 +594,10 @@ namespace SQLQueryStress
             this.actualSeconds_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.actualSeconds_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.actualSeconds_textBox.ForeColor = System.Drawing.Color.Lime;
-            this.actualSeconds_textBox.Location = new System.Drawing.Point(4, 578);
-            this.actualSeconds_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.actualSeconds_textBox.Location = new System.Drawing.Point(3, 375);
+            this.actualSeconds_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.actualSeconds_textBox.Name = "actualSeconds_textBox";
-            this.actualSeconds_textBox.Size = new System.Drawing.Size(295, 39);
+            this.actualSeconds_textBox.Size = new System.Drawing.Size(196, 26);
             this.actualSeconds_textBox.TabIndex = 7;
             this.actualSeconds_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -631,22 +609,20 @@ namespace SQLQueryStress
             this.tableLayoutPanel2.Controls.Add(this.cancel_button, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.go_button, 0, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(307, 5);
-            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(205, 3);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(295, 70);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(196, 46);
             this.tableLayoutPanel2.TabIndex = 8;
             // 
             // param_button
             // 
             this.param_button.Dock = System.Windows.Forms.DockStyle.Fill;
             this.param_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.param_button.Location = new System.Drawing.Point(4, 184);
-            this.param_button.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.param_button.Location = new System.Drawing.Point(3, 119);
             this.param_button.Name = "param_button";
-            this.param_button.Size = new System.Drawing.Size(295, 45);
+            this.param_button.Size = new System.Drawing.Size(196, 30);
             this.param_button.TabIndex = 2;
             this.param_button.Text = "Parameter Substitution";
             this.param_button.UseVisualStyleBackColor = true;
@@ -660,22 +636,21 @@ namespace SQLQueryStress
             this.tableLayoutPanel4.Controls.Add(this.btnFreeCache, 1, 0);
             this.tableLayoutPanel4.Controls.Add(this.btnCleanBuffer, 0, 0);
             this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel4.Location = new System.Drawing.Point(4, 5);
-            this.tableLayoutPanel4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             this.tableLayoutPanel4.RowCount = 2;
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(295, 70);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(196, 46);
             this.tableLayoutPanel4.TabIndex = 0;
             // 
             // btnFreeCache
             // 
             this.btnFreeCache.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.btnFreeCache.Location = new System.Drawing.Point(149, 2);
-            this.btnFreeCache.Margin = new System.Windows.Forms.Padding(2);
+            this.btnFreeCache.Location = new System.Drawing.Point(99, 1);
+            this.btnFreeCache.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
             this.btnFreeCache.Name = "btnFreeCache";
-            this.btnFreeCache.Size = new System.Drawing.Size(144, 31);
+            this.btnFreeCache.Size = new System.Drawing.Size(96, 21);
             this.btnFreeCache.TabIndex = 1;
             this.btnFreeCache.Text = "Free Cache";
             this.btnFreeCache.UseVisualStyleBackColor = true;
@@ -684,10 +659,10 @@ namespace SQLQueryStress
             // btnCleanBuffer
             // 
             this.btnCleanBuffer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.btnCleanBuffer.Location = new System.Drawing.Point(2, 2);
-            this.btnCleanBuffer.Margin = new System.Windows.Forms.Padding(2);
+            this.btnCleanBuffer.Location = new System.Drawing.Point(1, 1);
+            this.btnCleanBuffer.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
             this.btnCleanBuffer.Name = "btnCleanBuffer";
-            this.btnCleanBuffer.Size = new System.Drawing.Size(143, 31);
+            this.btnCleanBuffer.Size = new System.Drawing.Size(96, 21);
             this.btnCleanBuffer.TabIndex = 0;
             this.btnCleanBuffer.Text = "Clean Buffers";
             this.btnCleanBuffer.UseVisualStyleBackColor = true;
@@ -698,20 +673,18 @@ namespace SQLQueryStress
             this.label11.AutoSize = true;
             this.label11.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
-            this.label11.Location = new System.Drawing.Point(4, 388);
-            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label11.Location = new System.Drawing.Point(3, 252);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(295, 22);
+            this.label11.Size = new System.Drawing.Size(196, 14);
             this.label11.TabIndex = 34;
             this.label11.Text = "Delay between queries (ms)";
             // 
             // queryDelay_textBox
             // 
             this.queryDelay_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.queryDelay_textBox.Location = new System.Drawing.Point(4, 415);
-            this.queryDelay_textBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.queryDelay_textBox.Location = new System.Drawing.Point(3, 269);
             this.queryDelay_textBox.Name = "queryDelay_textBox";
-            this.queryDelay_textBox.Size = new System.Drawing.Size(295, 26);
+            this.queryDelay_textBox.Size = new System.Drawing.Size(196, 20);
             this.queryDelay_textBox.TabIndex = 5;
             this.queryDelay_textBox.Text = "0";
             // 
@@ -723,39 +696,36 @@ namespace SQLQueryStress
             this.tableLayoutPanel3.Controls.Add(this.tableLayoutPanel1, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.elementHost1, 0, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 35);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(1112, 633);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(741, 410);
             this.tableLayoutPanel3.TabIndex = 2;
             // 
             // elementHost1
             // 
             this.elementHost1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.elementHost1.Location = new System.Drawing.Point(4, 5);
-            this.elementHost1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.elementHost1.Location = new System.Drawing.Point(3, 3);
             this.elementHost1.Name = "elementHost1";
-            this.elementHost1.Size = new System.Drawing.Size(490, 623);
+            this.elementHost1.Size = new System.Drawing.Size(325, 404);
             this.elementHost1.TabIndex = 0;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(1112, 668);
+            this.ClientSize = new System.Drawing.Size(741, 434);
             this.Controls.Add(this.tableLayoutPanel3);
             this.Controls.Add(this.db_label);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MinimumSize = new System.Drawing.Size(1112, 621);
+            this.MinimumSize = new System.Drawing.Size(747, 473);
             this.Name = "Form1";
             this.Text = "SQLQueryStress";
             this.menuStrip1.ResumeLayout(false);

--- a/src/SQLQueryStress/ParamWindow.Designer.cs
+++ b/src/SQLQueryStress/ParamWindow.Designer.cs
@@ -47,6 +47,8 @@ namespace SQLQueryStress
             // 
             this.columnMapGrid.AllowUserToAddRows = false;
             this.columnMapGrid.AllowUserToDeleteRows = false;
+            this.columnMapGrid.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.columnMapGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.columnMapGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Column,
@@ -55,7 +57,7 @@ namespace SQLQueryStress
             this.columnMapGrid.Location = new System.Drawing.Point(12, 274);
             this.columnMapGrid.Name = "columnMapGrid";
             this.columnMapGrid.ShowEditingIcon = false;
-            this.columnMapGrid.Size = new System.Drawing.Size(435, 185);
+            this.columnMapGrid.Size = new System.Drawing.Size(438, 185);
             this.columnMapGrid.TabIndex = 3;
             // 
             // Column
@@ -88,6 +90,7 @@ namespace SQLQueryStress
             // 
             // getColumnsButton
             // 
+            this.getColumnsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.getColumnsButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.getColumnsButton.Location = new System.Drawing.Point(15, 219);
             this.getColumnsButton.Name = "getColumnsButton";
@@ -99,8 +102,9 @@ namespace SQLQueryStress
             // 
             // okButton
             // 
+            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.okButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.okButton.Location = new System.Drawing.Point(291, 465);
+            this.okButton.Location = new System.Drawing.Point(294, 465);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 4;
@@ -110,9 +114,10 @@ namespace SQLQueryStress
             // 
             // cancelButton
             // 
+            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.cancelButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cancelButton.Location = new System.Drawing.Point(372, 465);
+            this.cancelButton.Location = new System.Drawing.Point(375, 465);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 5;
@@ -122,6 +127,7 @@ namespace SQLQueryStress
             // 
             // label2
             // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.Location = new System.Drawing.Point(12, 258);
@@ -132,6 +138,7 @@ namespace SQLQueryStress
             // 
             // database_button
             // 
+            this.database_button.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.database_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.database_button.Location = new System.Drawing.Point(119, 219);
             this.database_button.Name = "database_button";
@@ -143,9 +150,12 @@ namespace SQLQueryStress
             // 
             // elementHost1
             // 
-            this.elementHost1.Location = new System.Drawing.Point(15, 36);
+            this.elementHost1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.elementHost1.Location = new System.Drawing.Point(12, 36);
             this.elementHost1.Name = "elementHost1";
-            this.elementHost1.Size = new System.Drawing.Size(432, 177);
+            this.elementHost1.Size = new System.Drawing.Size(438, 177);
             this.elementHost1.TabIndex = 0;
             this.elementHost1.Text = "elementHost1";
             this.elementHost1.Child = this.sqlControl1;
@@ -165,12 +175,13 @@ namespace SQLQueryStress
             this.Controls.Add(this.getColumnsButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.columnMapGrid);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(450, 500);
             this.Name = "ParamWindow";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.Text = "Parameter Substitution";
             ((System.ComponentModel.ISupportInitialize)(this.columnMapGrid)).EndInit();
             this.ResumeLayout(false);

--- a/src/SQLQueryStress/ParamWindow.resx
+++ b/src/SQLQueryStress/ParamWindow.resx
@@ -126,4 +126,13 @@
   <metadata name="Parameter.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="Column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Datatype.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Parameter.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>


### PR DESCRIPTION
I made ParamWindow resizable so that when the parameter loading scripts are long, they can be viewed easily.  
It can look like this now:  
![image](https://user-images.githubusercontent.com/8049594/61283187-a1ae0900-a7b4-11e9-956d-6d17464bdc94.png)


I also changed the minimum height of the main form to prevent it clipping "actual seconds" box when resized. 

