### PR TITLE
Feature to save results to csv 

### DIFF
--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -56,6 +56,9 @@ namespace SQLQueryStress
             this.saveSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveBenchMarkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toCsvToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -150,40 +153,64 @@ namespace SQLQueryStress
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(158, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(177, 6);
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.optionsToolStripMenuItem.Text = "Options";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // saveSettingsToolStripMenuItem
             // 
             this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
-            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveSettingsToolStripMenuItem.Text = "Save Settings";
             this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
             // 
             // loadSettingsToolStripMenuItem
             // 
             this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
-            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.loadSettingsToolStripMenuItem.Text = "Load Settings";
             this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
             // 
             // saveBenchMarkToolStripMenuItem
             // 
+            this.saveBenchMarkToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toCsvToolStripMenuItem,
+            this.toTextToolStripMenuItem,
+            this.toClipboardToolStripMenuItem});
             this.saveBenchMarkToolStripMenuItem.Name = "saveBenchMarkToolStripMenuItem";
-            this.saveBenchMarkToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.saveBenchMarkToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveBenchMarkToolStripMenuItem.Text = "Save BenchMark";
-            this.saveBenchMarkToolStripMenuItem.Click += new System.EventHandler(this.saveBenchMarkToolStripMenuItem_Click);
+            // 
+            // toCsvToolStripMenuItem
+            // 
+            this.toCsvToolStripMenuItem.Name = "toCsvToolStripMenuItem";
+            this.toCsvToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.toCsvToolStripMenuItem.Text = "To Csv";
+            this.toCsvToolStripMenuItem.Click += new System.EventHandler(this.toCsvToolStripMenuItem_Click);
+            // 
+            // toTextToolStripMenuItem
+            // 
+            this.toTextToolStripMenuItem.Name = "toTextToolStripMenuItem";
+            this.toTextToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.toTextToolStripMenuItem.Text = "To Text";
+            this.toTextToolStripMenuItem.Click += new System.EventHandler(this.toTextToolStripMenuItem_Click);
+            // 
+            // toClipboardToolStripMenuItem
+            // 
+            this.toClipboardToolStripMenuItem.Name = "toClipboardToolStripMenuItem";
+            this.toClipboardToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.toClipboardToolStripMenuItem.Text = "To Clipboard";
+            this.toClipboardToolStripMenuItem.Click += new System.EventHandler(this.toClipboardToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -333,7 +360,7 @@ namespace SQLQueryStress
             this.avgSeconds_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.avgSeconds_textBox.ForeColor = System.Drawing.Color.Lime;
             this.avgSeconds_textBox.Location = new System.Drawing.Point(205, 219);
-            this.avgSeconds_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.avgSeconds_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.avgSeconds_textBox.Name = "avgSeconds_textBox";
             this.avgSeconds_textBox.Size = new System.Drawing.Size(196, 30);
             this.avgSeconds_textBox.TabIndex = 12;
@@ -378,7 +405,7 @@ namespace SQLQueryStress
             this.totalExceptions_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.totalExceptions_textBox.ForeColor = System.Drawing.Color.Red;
             this.totalExceptions_textBox.Location = new System.Drawing.Point(3, 3);
-            this.totalExceptions_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.totalExceptions_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.totalExceptions_textBox.Name = "totalExceptions_textBox";
             this.totalExceptions_textBox.Size = new System.Drawing.Size(155, 30);
             this.totalExceptions_textBox.TabIndex = 1;
@@ -408,7 +435,7 @@ namespace SQLQueryStress
             this.elapsedTime_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.elapsedTime_textBox.ForeColor = System.Drawing.Color.Lime;
             this.elapsedTime_textBox.Location = new System.Drawing.Point(205, 119);
-            this.elapsedTime_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.elapsedTime_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.elapsedTime_textBox.Name = "elapsedTime_textBox";
             this.elapsedTime_textBox.Size = new System.Drawing.Size(196, 30);
             this.elapsedTime_textBox.TabIndex = 10;
@@ -438,7 +465,7 @@ namespace SQLQueryStress
             this.iterationsSecond_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.iterationsSecond_textBox.ForeColor = System.Drawing.Color.Lime;
             this.iterationsSecond_textBox.Location = new System.Drawing.Point(205, 169);
-            this.iterationsSecond_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.iterationsSecond_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.iterationsSecond_textBox.Name = "iterationsSecond_textBox";
             this.iterationsSecond_textBox.Size = new System.Drawing.Size(196, 30);
             this.iterationsSecond_textBox.TabIndex = 11;
@@ -474,7 +501,7 @@ namespace SQLQueryStress
             this.cpuTime_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cpuTime_textBox.ForeColor = System.Drawing.Color.Lime;
             this.cpuTime_textBox.Location = new System.Drawing.Point(3, 319);
-            this.cpuTime_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.cpuTime_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.cpuTime_textBox.Name = "cpuTime_textBox";
             this.cpuTime_textBox.Size = new System.Drawing.Size(196, 30);
             this.cpuTime_textBox.TabIndex = 6;
@@ -499,7 +526,7 @@ namespace SQLQueryStress
             this.logicalReads_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.logicalReads_textBox.ForeColor = System.Drawing.Color.Lime;
             this.logicalReads_textBox.Location = new System.Drawing.Point(205, 319);
-            this.logicalReads_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.logicalReads_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.logicalReads_textBox.Name = "logicalReads_textBox";
             this.logicalReads_textBox.Size = new System.Drawing.Size(196, 30);
             this.logicalReads_textBox.TabIndex = 14;
@@ -595,7 +622,7 @@ namespace SQLQueryStress
             this.actualSeconds_textBox.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.actualSeconds_textBox.ForeColor = System.Drawing.Color.Lime;
             this.actualSeconds_textBox.Location = new System.Drawing.Point(3, 375);
-            this.actualSeconds_textBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.actualSeconds_textBox.Margin = new System.Windows.Forms.Padding(3);
             this.actualSeconds_textBox.Name = "actualSeconds_textBox";
             this.actualSeconds_textBox.Size = new System.Drawing.Size(196, 26);
             this.actualSeconds_textBox.TabIndex = 7;
@@ -648,7 +675,7 @@ namespace SQLQueryStress
             // 
             this.btnFreeCache.Dock = System.Windows.Forms.DockStyle.Fill;
             this.btnFreeCache.Location = new System.Drawing.Point(99, 1);
-            this.btnFreeCache.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.btnFreeCache.Margin = new System.Windows.Forms.Padding(1);
             this.btnFreeCache.Name = "btnFreeCache";
             this.btnFreeCache.Size = new System.Drawing.Size(96, 21);
             this.btnFreeCache.TabIndex = 1;
@@ -660,7 +687,7 @@ namespace SQLQueryStress
             // 
             this.btnCleanBuffer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.btnCleanBuffer.Location = new System.Drawing.Point(1, 1);
-            this.btnCleanBuffer.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.btnCleanBuffer.Margin = new System.Windows.Forms.Padding(1);
             this.btnCleanBuffer.Name = "btnCleanBuffer";
             this.btnCleanBuffer.Size = new System.Drawing.Size(96, 21);
             this.btnCleanBuffer.TabIndex = 0;
@@ -797,6 +824,9 @@ namespace SQLQueryStress
         private System.Windows.Forms.Integration.ElementHost elementHost1;
         private SqlControl sqlControl1;
         private ToolStripMenuItem saveBenchMarkToolStripMenuItem;
+        private ToolStripMenuItem toCsvToolStripMenuItem;
+        private ToolStripMenuItem toTextToolStripMenuItem;
+        private ToolStripMenuItem toClipboardToolStripMenuItem;
     }
 }
 

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -584,6 +584,7 @@ namespace SQLQueryStress
         {
             var saveFileDialog = new SaveFileDialog();
             saveFileDialog.AddExtension = true;
+            saveFileDialog.OverwritePrompt = false;
             saveFileDialog.Filter = "Text Files (*.txt)|*.txt";
             saveFileDialog.ShowDialog();
 
@@ -595,7 +596,7 @@ namespace SQLQueryStress
         {
             try
             {
-                var textWriter = new StreamWriter(fileName);
+                var textWriter = new StreamWriter(fileName, true);
                 WriteBenchmarkTextContent(textWriter);
                 textWriter.Close();
             }
@@ -655,6 +656,7 @@ namespace SQLQueryStress
         {
             var saveFileDialog = new SaveFileDialog();
             saveFileDialog.AddExtension = true;
+            saveFileDialog.OverwritePrompt = false;
             saveFileDialog.Filter = "Csv Files (*.csv)|*.csv";
             saveFileDialog.ShowDialog();
 
@@ -667,8 +669,12 @@ namespace SQLQueryStress
             try
             {
                 var fileExists = File.Exists(fileName);
-                var textWriter = new StreamWriter(fileName);
-
+                var textWriter = new StreamWriter(fileName, true);
+                // we do not write the header line if we are appending to an existing file 
+                if (fileExists == false)
+                {
+                    WriteBenchmarkCsvHeader(textWriter);
+                }
                 WriteBenchmarkCsvText(textWriter);
                 textWriter.Close();
             }
@@ -680,9 +686,13 @@ namespace SQLQueryStress
             }
         }
 
-        private void WriteBenchmarkCsvText(TextWriter tw)
+        private void WriteBenchmarkCsvHeader(StreamWriter tw)
         {
             tw.WriteLine("TestId,TestStartTime,ElapsedTime,Iterations,Threads,Delay,CompletedIterations,AvgCPUSeconds,AvgActualSeconds,AvgClientSeconds,AvgLogicalReads");
+        }
+
+        private void WriteBenchmarkCsvText(TextWriter tw)
+        {
             tw.WriteLine("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}",
                 _testGuid,
                 _testStartTime,

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -79,6 +79,10 @@ namespace SQLQueryStress
         //WAITFOR DELAY '00:00:05'  (1300 ms?? WTF??)
         private int _totalTimeMessages;
 
+        private DateTime _testStartTime;
+
+        private Guid _testGuid;
+
         public Form1(string configFile, bool unattendedMode, int numThreads) : this()
         {
             var fileExists = File.Exists(configFile);
@@ -249,6 +253,8 @@ namespace SQLQueryStress
                 return;
             }
 
+            _testStartTime = DateTime.Now;
+            _testGuid = Guid.NewGuid();
             _cancelled = false;
             _exitOnComplete = false;
 
@@ -573,43 +579,25 @@ namespace SQLQueryStress
                 : "Errors encountered");
         }
 
-        private void saveBenchMarkToolStripMenuItem_Click(object sender, EventArgs e)
+
+        private void toTextToolStripMenuItem_Click(object sender, EventArgs e)
         {
-           var saveFileDialog = new SaveFileDialog();
+            var saveFileDialog = new SaveFileDialog();
             saveFileDialog.AddExtension = true;
             saveFileDialog.Filter = "Text Files (*.txt)|*.txt";
             saveFileDialog.ShowDialog();
 
-            if(!string.IsNullOrEmpty(saveFileDialog.FileName))
-            ExportBenchMarkToFile(saveFileDialog.FileName);
+            if (!string.IsNullOrEmpty(saveFileDialog.FileName))
+                ExportBenchMarkToTextFile(saveFileDialog.FileName);
         }
 
-        private void ExportBenchMarkToFile(string fileName)
+        private void ExportBenchMarkToTextFile(string fileName)
         {
             try
             {
-                var file = new StreamWriter(fileName);
-                file.WriteLine(string.Format("Test TimeStamp: {0}", 
-                    DateTime.Now));
-                file.WriteLine(string.Format("Elapsed Time: {0}", 
-                    elapsedTime_textBox.Text));
-                file.WriteLine(string.Format("Number of Iterations: {0}", 
-                    (int) iterations_numericUpDown.Value));
-                file.WriteLine(string.Format("Number of Threads: {0}", 
-                    (int) threads_numericUpDown.Value));
-                file.WriteLine(string.Format("Delay Between Queries (ms): {0}", 
-                    int.Parse(queryDelay_textBox.Text)));
-                file.WriteLine(string.Format("CPU Seconds/Iteration (Avg): {0}",
-                    cpuTime_textBox.Text));
-                file.WriteLine(string.Format("Actual Seconds/Iteration (Avg): {0}",
-                    actualSeconds_textBox.Text));
-                file.WriteLine(string.Format("Iterations Completed: {0}",
-                    iterationsSecond_textBox.Text));
-                file.WriteLine(string.Format("Client Seconds/Iteration (Avg): {0}",
-                    avgSeconds_textBox.Text));
-                file.WriteLine(string.Format("Logical Reads/Iteration (Avg): {0}",
-                    logicalReads_textBox.Text));
-                file.Close();
+                var textWriter = new StreamWriter(fileName);
+                WriteBenchmarkTextContent(textWriter);
+                textWriter.Close();
             }
             catch
             {
@@ -618,5 +606,98 @@ namespace SQLQueryStress
                     string.Format("There was an error saving the benchmark to '{0}', make sure you have write privileges to that path",fileName));
             }
         }
+
+        private void WriteBenchmarkTextContent(TextWriter tw)
+        {
+            tw.WriteLine(string.Format("Test ID: {0}",
+                                _testGuid));
+            tw.WriteLine(string.Format("Test TimeStamp: {0}",
+                                _testStartTime));
+            tw.WriteLine(string.Format("Elapsed Time: {0}",
+                elapsedTime_textBox.Text));
+            tw.WriteLine(string.Format("Number of Iterations: {0}",
+                (int)iterations_numericUpDown.Value));
+            tw.WriteLine(string.Format("Number of Threads: {0}",
+                (int)threads_numericUpDown.Value));
+            tw.WriteLine(string.Format("Delay Between Queries (ms): {0}",
+                int.Parse(queryDelay_textBox.Text)));
+            tw.WriteLine(string.Format("CPU Seconds/Iteration (Avg): {0}",
+                cpuTime_textBox.Text));
+            tw.WriteLine(string.Format("Actual Seconds/Iteration (Avg): {0}",
+                actualSeconds_textBox.Text));
+            tw.WriteLine(string.Format("Iterations Completed: {0}",
+                iterationsSecond_textBox.Text));
+            tw.WriteLine(string.Format("Client Seconds/Iteration (Avg): {0}",
+                avgSeconds_textBox.Text));
+            tw.WriteLine(string.Format("Logical Reads/Iteration (Avg): {0}",
+                logicalReads_textBox.Text));
+            tw.WriteLine("");
+        }
+
+
+        private void toClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var textWriter = new StringWriter();
+                WriteBenchmarkTextContent(textWriter);
+                Clipboard.SetText(textWriter.ToString());
+            }
+            catch
+            {
+                MessageBox
+                    .Show("Error While Copying BenchMark to Clipboard",
+                    string.Format("There was an error copying the benchmark to clipboard"));
+            }
+        }
+
+        private void toCsvToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var saveFileDialog = new SaveFileDialog();
+            saveFileDialog.AddExtension = true;
+            saveFileDialog.Filter = "Csv Files (*.csv)|*.csv";
+            saveFileDialog.ShowDialog();
+
+            if (!string.IsNullOrEmpty(saveFileDialog.FileName))
+                ExportBenchMarkToCsvFile(saveFileDialog.FileName);
+        }
+
+        private void ExportBenchMarkToCsvFile(string fileName)
+        {
+            try
+            {
+                var fileExists = File.Exists(fileName);
+                var textWriter = new StreamWriter(fileName);
+
+                WriteBenchmarkCsvText(textWriter);
+                textWriter.Close();
+            }
+            catch
+            {
+                MessageBox
+                    .Show("Error While Saving BenchMark",
+                    string.Format("There was an error saving the benchmark to '{0}', make sure you have write privileges to that path", fileName));
+            }
+        }
+
+        private void WriteBenchmarkCsvText(TextWriter tw)
+        {
+            tw.WriteLine("TestId,TestStartTime,ElapsedTime,Iterations,Threads,Delay,CompletedIterations,AvgCPUSeconds,AvgActualSeconds,AvgClientSeconds,AvgLogicalReads");
+            tw.WriteLine("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}",
+                _testGuid,
+                _testStartTime,
+                elapsedTime_textBox.Text,
+                (int)iterations_numericUpDown.Value,
+                (int)threads_numericUpDown.Value,
+                int.Parse(queryDelay_textBox.Text),
+                iterationsSecond_textBox.Text,
+                cpuTime_textBox.Text,
+                actualSeconds_textBox.Text,
+                avgSeconds_textBox.Text,
+                logicalReads_textBox.Text
+                );
+        }
+
+
     }
 }


### PR DESCRIPTION
A feature to save benchmark results to Csv file is added.  In order to achieve this:  
- New option to save to csv is added to the application menu. It is now like this:  
![image](https://user-images.githubusercontent.com/8049594/61647371-1eede800-aca5-11e9-950a-b8fd71ad7039.png)

- Default file handling behaviour for existing files is changed from "overwrite" to "append". This enables the user to run multiple benchmarks and append to the same file, then analyse/graph results easily. 

- As a side feature export to clipboard is added. 

- In order to identify multiple benchmarks test guid and test start time data is added, populated and exported (but not displayed on the screen (yet)). 

A sample csv file looks like this:  
![image](https://user-images.githubusercontent.com/8049594/61647690-d256dc80-aca5-11e9-981d-9709569dbdda.png)
