### PR TITLE
Cmdline feature autosave results to csv

### DIFF
--- a/src/SQLQueryStress/CommandLineOptions.cs
+++ b/src/SQLQueryStress/CommandLineOptions.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using CommandLine.Text;
+using System.Collections.Generic;
 
 namespace SQLQueryStress
 {
@@ -9,11 +10,15 @@ namespace SQLQueryStress
 
         [Option("c", null,
                 HelpText = "File name of saved session settings\r\n")]
-        public string SessionFile = string.Empty;
+        public string SettingsFile = string.Empty;
 
         [Option("u", null,
                 HelpText = "Run unattended (start, run settings file and quit)")]
         public bool Unattended = false;
+
+        [Option("r", null, 
+                HelpText = "Autosave results to specified file")]
+        public string ResultsAutoSaveFileName = string.Empty; 
 
         [Option("t", null,
                 HelpText = "Number of threads in unattended mode")]
@@ -28,7 +33,7 @@ namespace SQLQueryStress
             help.AddPreOptionsLine("Check for updates at: https://github.com/ErikEJ/SqlQueryStress");
             help.AddPreOptionsLine("");
             help.AddPreOptionsLine("Sample usage:");
-            help.AddPreOptionsLine("SqlQueryStress -c \"saved.SqlStress\" -u  -t 32");
+            help.AddPreOptionsLine("SqlQueryStress -c saved.SqlStress -u -t 32 -r results.csv");
             help.AddOptions(this);
             return help;
         }

--- a/src/SQLQueryStress/CommandLineOptions.cs
+++ b/src/SQLQueryStress/CommandLineOptions.cs
@@ -18,7 +18,11 @@ namespace SQLQueryStress
 
         [Option("r", null, 
                 HelpText = "Autosave results to specified file")]
-        public string ResultsAutoSaveFileName = string.Empty; 
+        public string ResultsAutoSaveFileName = string.Empty;
+
+        [Option("d", null,
+                HelpText = "Database Server")]
+        public string DbServer = string.Empty;
 
         [Option("t", null,
                 HelpText = "Number of threads in unattended mode")]
@@ -33,7 +37,7 @@ namespace SQLQueryStress
             help.AddPreOptionsLine("Check for updates at: https://github.com/ErikEJ/SqlQueryStress");
             help.AddPreOptionsLine("");
             help.AddPreOptionsLine("Sample usage:");
-            help.AddPreOptionsLine("SqlQueryStress -c saved.SqlStress -u -t 32 -r results.csv");
+            help.AddPreOptionsLine("SqlQueryStress -c saved.SqlStress -u -t 32 -d sqldb.perfenv.mycompany.com -r results.csv");
             help.AddOptions(this);
             return help;
         }

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -417,7 +417,7 @@ namespace SQLQueryStress
                     {
                         conn.Open();
                     }
-                    catch 
+                    catch (Exception exc)
                     {
                         return false;
                     }

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -110,6 +110,11 @@ namespace SQLQueryStress
             {
                 threads_numericUpDown.Value = _settings.NumThreads = _runParameters.NumberOfThreads;
             }
+
+            if (string.IsNullOrWhiteSpace(_runParameters.DbServer) == false)
+            {
+                _settings.MainDbConnectionInfo.Server = _runParameters.DbServer; 
+            }
         }
 
         public Form1()

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -65,7 +65,6 @@ namespace SQLQueryStress
         //This is the total time as reported by the client
         private double _totalTime;
 
-        private readonly bool _unattendedMode;
         //Number of query requests that returned time messages
         //Note:: Average times will be computed by:
         // A) Add up all results from time messages returned by 
@@ -83,22 +82,34 @@ namespace SQLQueryStress
 
         private Guid _testGuid;
 
-        public Form1(string configFile, bool unattendedMode, int numThreads) : this()
+        private CommandLineOptions _runParameters; 
+
+        public Form1(CommandLineOptions runParameters) : this()
         {
-            var fileExists = File.Exists(configFile);
-            // load config file if specified
-            if (!string.IsNullOrWhiteSpace(configFile)
-                && fileExists)
+            _runParameters = runParameters;
+
+            if (string.IsNullOrWhiteSpace(_runParameters.SettingsFile) == false)
             {
-                OpenConfigFile(configFile);
+                var isConfigFileExists = File.Exists(_runParameters.SettingsFile); 
+                if (isConfigFileExists)
+                {
+                    OpenConfigFile(_runParameters.SettingsFile);
+                    if (_runParameters.Unattended)
+                    {
+                        Load += StartProcessing;
+                    }
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format("Settings file could not be found: {0}", _runParameters.SettingsFile));
+                }
             }
 
-            // set the start processing after form is loaded
-            _unattendedMode = unattendedMode;
-            if (unattendedMode && fileExists) Load += StartProcessing;
-            
             // are we overriding the config file?
-            if (numThreads > 0) threads_numericUpDown.Value = _settings.NumThreads = numThreads;
+            if (_runParameters.NumberOfThreads > 0)
+            {
+                threads_numericUpDown.Value = _settings.NumThreads = _runParameters.NumberOfThreads;
+            }
         }
 
         public Form1()
@@ -208,10 +219,28 @@ namespace SQLQueryStress
 
             db_label.Text = "";
 
+            if (string.IsNullOrEmpty(_runParameters.ResultsAutoSaveFileName) == false)
+            {
+                AutoSaveResults(_runParameters.ResultsAutoSaveFileName); 
+            }
+
             // if we started automatically exit when done
-            if (_exitOnComplete || _unattendedMode)
+            if (_exitOnComplete || _runParameters.Unattended)
             {
                 Dispose();
+            }
+        }
+
+        private void AutoSaveResults(string resultsAutoSaveFileName)
+        {
+            string extension = Path.GetExtension(resultsAutoSaveFileName).ToLower();
+            if (extension == ".csv")
+            {
+                ExportBenchMarkToCsvFile(resultsAutoSaveFileName);
+            }
+            else
+            {
+                ExportBenchMarkToTextFile(resultsAutoSaveFileName);
             }
         }
 

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -19,26 +19,19 @@ namespace SQLQueryStress
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var configFileName = string.Empty;
-            var unattendedMode = false;
-            int numThreads = -1;
 
             var options = new CommandLineOptions();
             ICommandLineParser parser = new CommandLineParser();
             var writer = new StringWriter();
-            if (parser.ParseArguments(args, options, writer))
-            {
-                configFileName = options.SessionFile;
-                unattendedMode = options.Unattended;
-                numThreads = options.NumberOfThreads;
-            }
+            parser.ParseArguments(args, options, writer);
+            
             if (writer.GetStringBuilder().Length > 0)
             {
                 MessageBox.Show(writer.GetStringBuilder().ToString());
             }
             else
             {
-                var f = new Form1(configFileName, unattendedMode, numThreads)
+                var f = new Form1(options)
                 {
                     StartPosition = FormStartPosition.CenterScreen
                 };

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -39,7 +39,7 @@
     <ProductName>SQLQueryStress</ProductName>
     <PublisherName>Adam Machanic</PublisherName>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.10.0.0</ApplicationVersion>
+    <ApplicationVersion>0.9.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -39,7 +39,7 @@
     <ProductName>SQLQueryStress</ProductName>
     <PublisherName>Adam Machanic</PublisherName>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.9.0.0</ApplicationVersion>
+    <ApplicationVersion>0.10.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>


### PR DESCRIPTION
Two new options are added to command line:  
1. r :  ResultsAutoSaveFileName : When specified, results are automatically saved (in conjunction with the previous changes actually appended) to the specified file.  
2. d : DbServer : When specified, overrides the existing setting's database server address. This is useful for running the same saved benchmark in different environments from command line without modifying the saved settings file. 
Examples: 
`SqlQueryStress -c saved.SqlStress -u -t 1 -d . -r results.local.csv`
`SqlQueryStress -c saved.SqlStress -u -t 32 -d sqldb.perf.mycompany.com -r results.perf.csv`
