### PR TITLE
Crash fix, add UI framerate limiter during tests, fix warnings

### DIFF
--- a/src/SQLQueryStress/AboutBox.Designer.cs
+++ b/src/SQLQueryStress/AboutBox.Designer.cs
@@ -142,7 +142,7 @@ namespace SQLQueryStress
             this.textBoxDescription.TabStop = false;
             this.textBoxDescription.Text = "Please visit https://github.com/ErikEJ/SqlQueryStress for documentation and updat" +
     "es!";
-            this.textBoxDescription.Click += new System.EventHandler(this.textBoxDescription_Click);
+            this.textBoxDescription.Click += new System.EventHandler(this.TextBoxDescription_Click);
             // 
             // okButton
             // 
@@ -153,7 +153,7 @@ namespace SQLQueryStress
             this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 24;
             this.okButton.Text = "&OK";
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            this.okButton.Click += new System.EventHandler(this.OkButton_Click);
             // 
             // AboutBox
             // 

--- a/src/SQLQueryStress/AboutBox.cs
+++ b/src/SQLQueryStress/AboutBox.cs
@@ -78,7 +78,7 @@ Settings for a test, including the query, database information, and parameter as
 
         #region Assembly Attribute Accessors
 
-        public string AssemblyTitle
+        public static string AssemblyTitle
         {
             get
             {
@@ -98,12 +98,12 @@ Settings for a test, including the query, database information, and parameter as
             }
         }
 
-        public string AssemblyVersion
+        public static string AssemblyVersion
         {
             get { return Assembly.GetExecutingAssembly().GetName().Version.ToString(); }
         }
 
-        public string AssemblyDescription
+        public static string AssemblyDescription
         {
             get
             {
@@ -117,7 +117,7 @@ Settings for a test, including the query, database information, and parameter as
             }
         }
 
-        public string AssemblyProduct
+        public static string AssemblyProduct
         {
             get
             {
@@ -131,7 +131,7 @@ Settings for a test, including the query, database information, and parameter as
             }
         }
 
-        public string AssemblyCopyright
+        public static string AssemblyCopyright
         {
             get
             {
@@ -145,7 +145,7 @@ Settings for a test, including the query, database information, and parameter as
             }
         }
 
-        public string AssemblyCompany
+        public static string AssemblyCompany
         {
             get
             {

--- a/src/SQLQueryStress/AboutBox.cs
+++ b/src/SQLQueryStress/AboutBox.cs
@@ -66,12 +66,12 @@ Settings for a test, including the query, database information, and parameter as
             set { base.Text = value; }
         }
 
-        private void okButton_Click(object sender, EventArgs e)
+        private void OkButton_Click(object sender, EventArgs e)
         {
             Dispose();
         }
 
-        private void textBoxDescription_Click(object sender, EventArgs e)
+        private void TextBoxDescription_Click(object sender, EventArgs e)
         {
             Process.Start("https://github.com/ErikEJ/SqlQueryStress");
         }
@@ -83,14 +83,14 @@ Settings for a test, including the query, database information, and parameter as
             get
             {
                 // Get all Title attributes on this assembly
-                var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof (AssemblyTitleAttribute), false);
+                object[] attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyTitleAttribute), false);
                 // If there is at least one Title attribute
                 if (attributes.Length > 0)
                 {
                     // Select the first one
-                    var titleAttribute = (AssemblyTitleAttribute) attributes[0];
+                    AssemblyTitleAttribute titleAttribute = (AssemblyTitleAttribute)attributes[0];
                     // If it is not an empty string, return it
-                    if (titleAttribute.Title != "")
+                    if (string.IsNullOrEmpty(titleAttribute.Title))
                         return titleAttribute.Title;
                 }
                 // If there was no Title attribute, or if the Title attribute was the empty string, return the .exe name
@@ -108,12 +108,12 @@ Settings for a test, including the query, database information, and parameter as
             get
             {
                 // Get all Description attributes on this assembly
-                var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof (AssemblyDescriptionAttribute), false);
+                object[] attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyDescriptionAttribute), false);
                 // If there aren't any Description attributes, return an empty string
                 if (attributes.Length == 0)
                     return "";
                 // If there is a Description attribute, return its value
-                return ((AssemblyDescriptionAttribute) attributes[0]).Description;
+                return ((AssemblyDescriptionAttribute)attributes[0]).Description;
             }
         }
 
@@ -122,12 +122,12 @@ Settings for a test, including the query, database information, and parameter as
             get
             {
                 // Get all Product attributes on this assembly
-                var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof (AssemblyProductAttribute), false);
+                object[] attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyProductAttribute), false);
                 // If there aren't any Product attributes, return an empty string
                 if (attributes.Length == 0)
                     return "";
                 // If there is a Product attribute, return its value
-                return ((AssemblyProductAttribute) attributes[0]).Product;
+                return ((AssemblyProductAttribute)attributes[0]).Product;
             }
         }
 
@@ -136,12 +136,12 @@ Settings for a test, including the query, database information, and parameter as
             get
             {
                 // Get all Copyright attributes on this assembly
-                var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof (AssemblyCopyrightAttribute), false);
+                object[] attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false);
                 // If there aren't any Copyright attributes, return an empty string
                 if (attributes.Length == 0)
                     return "";
                 // If there is a Copyright attribute, return its value
-                return ((AssemblyCopyrightAttribute) attributes[0]).Copyright;
+                return ((AssemblyCopyrightAttribute)attributes[0]).Copyright;
             }
         }
 
@@ -150,12 +150,12 @@ Settings for a test, including the query, database information, and parameter as
             get
             {
                 // Get all Company attributes on this assembly
-                var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof (AssemblyCompanyAttribute), false);
+                object[] attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(AssemblyCompanyAttribute), false);
                 // If there aren't any Company attributes, return an empty string
                 if (attributes.Length == 0)
                     return "";
                 // If there is a Company attribute, return its value
-                return ((AssemblyCompanyAttribute) attributes[0]).Company;
+                return ((AssemblyCompanyAttribute)attributes[0]).Company;
             }
         }
 

--- a/src/SQLQueryStress/App.config
+++ b/src/SQLQueryStress/App.config
@@ -3,4 +3,7 @@
   <runtime>
     <gcServer enabled="true"/>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+  </startup>
+</configuration>

--- a/src/SQLQueryStress/CommandLineOptions.cs
+++ b/src/SQLQueryStress/CommandLineOptions.cs
@@ -16,7 +16,7 @@ namespace SQLQueryStress
                 HelpText = "Run unattended (start, run settings file and quit)")]
         public bool Unattended = false;
 
-        [Option("r", null, 
+        [Option("r", null,
                 HelpText = "Autosave results to specified file")]
         public string ResultsAutoSaveFileName = string.Empty;
 
@@ -33,7 +33,7 @@ namespace SQLQueryStress
         public string GetUsage()
         {
             HelpText help = new HelpText(_headingInfo);
-            help.Copyright = new CopyrightInfo("Adam Machanic", 2006);
+            help.SetCopyright(new CopyrightInfo("Adam Machanic", 2006));
             help.AddPreOptionsLine("Check for updates at: https://github.com/ErikEJ/SqlQueryStress");
             help.AddPreOptionsLine("");
             help.AddPreOptionsLine("Sample usage:");

--- a/src/SQLQueryStress/CommandLineOptions.cs
+++ b/src/SQLQueryStress/CommandLineOptions.cs
@@ -1,6 +1,5 @@
 ﻿using CommandLine;
 using CommandLine.Text;
-using System.Collections.Generic;
 
 namespace SQLQueryStress
 {
@@ -42,6 +41,4 @@ namespace SQLQueryStress
             return help;
         }
     }
-
-
 }

--- a/src/SQLQueryStress/CommandLineParser/Attributes/BaseOptionAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/BaseOptionAttribute.cs
@@ -45,8 +45,8 @@ namespace CommandLine
         /// </summary>
         public string ShortName
         {
-            get { return this.shortName; }
-            internal set { this.shortName = value; }
+            get { return shortName; }
+            internal set { shortName = value; }
         }
 
         /// <summary>
@@ -54,8 +54,8 @@ namespace CommandLine
         /// </summary>
         public string LongName
         {
-            get { return this.longName; }
-            internal set { this.longName = value; }
+            get { return longName; }
+            internal set { longName = value; }
         }
 
         /// <summary>
@@ -63,18 +63,18 @@ namespace CommandLine
         /// </summary>
         public virtual bool Required
         {
-            get { return this.required; }
-            set { this.required = value; }
+            get { return required; }
+            set { required = value; }
         }
 
         internal bool HasShortName
         {
-            get { return !string.IsNullOrEmpty(this.shortName); }
+            get { return !string.IsNullOrEmpty(shortName); }
         }
 
         internal bool HasLongName
         {
-            get { return !string.IsNullOrEmpty(this.longName); }
+            get { return !string.IsNullOrEmpty(longName); }
         }
 
         /// <summary>
@@ -82,8 +82,8 @@ namespace CommandLine
         /// </summary>
         public string HelpText
         {
-            get { return this.helpText; }
-            set { this.helpText = value; }
+            get { return helpText; }
+            set { helpText = value; }
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Attributes/HelpOptionAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/HelpOptionAttribute.cs
@@ -57,8 +57,8 @@ namespace CommandLine
         /// <param name="longName">The long name of the option or null if not used.</param>
         public HelpOptionAttribute(string shortName, string longName)
         {
-            this.ShortName = shortName;
-            this.LongName = longName;
+            ShortName = shortName;
+            LongName = longName;
         }
 
         /// <summary>

--- a/src/SQLQueryStress/CommandLineParser/Attributes/HelpOptionAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/HelpOptionAttribute.cs
@@ -37,8 +37,8 @@ namespace CommandLine
     /// return value.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method,
-            AllowMultiple=false,
-            Inherited=true)]
+            AllowMultiple = false,
+            Inherited = true)]
     public sealed class HelpOptionAttribute : BaseOptionAttribute
     {
         /// <summary>

--- a/src/SQLQueryStress/CommandLineParser/Attributes/OptionAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/OptionAttribute.cs
@@ -49,20 +49,20 @@ namespace CommandLine
         {
             if (!string.IsNullOrEmpty(shortName))
             {
-                this.uniqueName = shortName;
+                uniqueName = shortName;
             }
             else if (!string.IsNullOrEmpty(longName))
             {
-                this.uniqueName = longName;
+                uniqueName = longName;
             }
 
-            if (this.uniqueName == null)
+            if (uniqueName == null)
             {
                 throw new InvalidOperationException();
             }
 
-            this.ShortName = shortName;
-            this.LongName = longName;
+            ShortName = shortName;
+            LongName = longName;
         }
 
 #if UNIT_TESTS
@@ -74,7 +74,7 @@ namespace CommandLine
 
         internal string UniqueName
         {
-            get { return this.uniqueName; }
+            get { return uniqueName; }
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Attributes/OptionAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/OptionAttribute.cs
@@ -34,11 +34,11 @@ namespace CommandLine
     /// Models an option specification.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field,
-            AllowMultiple=false,
-            Inherited=true)]
+            AllowMultiple = false,
+            Inherited = true)]
     public class OptionAttribute : BaseOptionAttribute
     {
-        private string uniqueName;
+        private readonly string uniqueName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.OptionAttribute"/> class.

--- a/src/SQLQueryStress/CommandLineParser/Attributes/OptionListAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/OptionListAttribute.cs
@@ -69,8 +69,8 @@ namespace CommandLine
         /// </summary>
         public char Separator
         {
-            get { return this.separator; }
-            set { this.separator = value; }
+            get { return separator; }
+            set { separator = value; }
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Attributes/OptionListAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/OptionListAttribute.cs
@@ -36,8 +36,8 @@ namespace CommandLine
     /// of <see cref="System.String"/> instances.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field,
-            AllowMultiple=false,
-            Inherited=true)]
+            AllowMultiple = false,
+            Inherited = true)]
     public sealed class OptionListAttribute : OptionAttribute
     {
         private char separator;

--- a/src/SQLQueryStress/CommandLineParser/Attributes/ValueListAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/ValueListAttribute.cs
@@ -38,11 +38,12 @@ namespace CommandLine
     /// of <see cref="System.String"/> instances.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field,
-            AllowMultiple=false,
-            Inherited=true)]
+            AllowMultiple = false,
+            Inherited = true)]
     public sealed class ValueListAttribute : Attribute
     {
-        private Type concreteType;
+        private const string Message = "The types are incompatible.";
+        private readonly Type concreteType;
         private int maximumElements;
 
         private ValueListAttribute()
@@ -60,11 +61,11 @@ namespace CommandLine
         {
             if (concreteType == null)
             {
-                throw new ArgumentNullException("concreteType");
+                throw new ArgumentNullException(nameof(concreteType));
             }
             if (!typeof(IList<string>).IsAssignableFrom(concreteType))
             {
-                throw new ParserException("The types are incompatible.");
+                throw new ParserException(Message);
             }
             this.concreteType = concreteType;
         }
@@ -87,8 +88,8 @@ namespace CommandLine
 
         internal static IList<string> GetReference(object target)
         {
-            Type concreteType;
-            FieldInfo field = GetField(target, out concreteType);
+            FieldInfo field = GetField(target, out Type concreteType);
+
             if (field == null)
             {
                 return null;

--- a/src/SQLQueryStress/CommandLineParser/Attributes/ValueListAttribute.cs
+++ b/src/SQLQueryStress/CommandLineParser/Attributes/ValueListAttribute.cs
@@ -48,7 +48,7 @@ namespace CommandLine
 
         private ValueListAttribute()
         {
-            this.maximumElements = -1;
+            maximumElements = -1;
         }
 
         /// <summary>
@@ -77,13 +77,13 @@ namespace CommandLine
         /// </summary>
         public int MaximumElements
         {
-            get { return this.maximumElements; }
-            set { this.maximumElements = value; }
+            get { return maximumElements; }
+            set { maximumElements = value; }
         }
 
         internal Type ConcreteType
         {
-            get { return this.concreteType; }
+            get { return concreteType; }
         }
 
         internal static IList<string> GetReference(object target)

--- a/src/SQLQueryStress/CommandLineParser/CommandLineParser.cs
+++ b/src/SQLQueryStress/CommandLineParser/CommandLineParser.cs
@@ -39,7 +39,7 @@ namespace CommandLine
     /// </summary>
     public class CommandLineParser : ICommandLineParser
     {
-        private object valueListLock = new object();
+        private readonly object valueListLock = new object();
 
         /// <summary>
         /// Parses a <see cref="System.String"/> array of command line arguments,
@@ -53,8 +53,8 @@ namespace CommandLine
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
         public virtual bool ParseArguments(string[] args, object options)
         {
-            Validator.CheckIsNull(args, "args");
-            Validator.CheckIsNull(options, "options");
+            Validator.CheckIsNull(args, nameof(args));
+            Validator.CheckIsNull(options, nameof(options));
 
             return ParseArgumentList(args, options);
         }
@@ -76,9 +76,9 @@ namespace CommandLine
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="helpWriter"/> is null.</exception>
         public virtual bool ParseArguments(string[] args, object options, TextWriter helpWriter)
         {
-            Validator.CheckIsNull(args, "args");
-            Validator.CheckIsNull(options, "options");
-            Validator.CheckIsNull(helpWriter, "helpWriter");
+            Validator.CheckIsNull(args, nameof(args));
+            Validator.CheckIsNull(options, nameof(options));
+            Validator.CheckIsNull(helpWriter, nameof(helpWriter));
 
             Pair<MethodInfo, HelpOptionAttribute> pair =
                                 ReflectionUtil.RetrieveMethod<HelpOptionAttribute>(options);
@@ -88,8 +88,7 @@ namespace CommandLine
             }
             if (ParseHelp(args, pair.Right) || !ParseArgumentList(args, options))
             {
-                string helpText;
-                HelpOptionAttribute.InvokeMethod(options, pair, out helpText);
+                HelpOptionAttribute.InvokeMethod(options, pair, out string helpText);
                 helpWriter.Write(helpText);
                 return false;
             }

--- a/src/SQLQueryStress/CommandLineParser/Core/CharEnumeratorEx.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/CharEnumeratorEx.cs
@@ -38,7 +38,7 @@ namespace CommandLine
 
         public CharEnumeratorEx(string value)
         {
-            Validator.CheckIsNullOrEmpty(value, "value");
+            Validator.CheckIsNullOrEmpty(value, nameof(value));
 
             this.data = value;
             this.index = -1;

--- a/src/SQLQueryStress/CommandLineParser/Core/CharEnumeratorEx.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/CharEnumeratorEx.cs
@@ -40,23 +40,23 @@ namespace CommandLine
         {
             Validator.CheckIsNullOrEmpty(value, nameof(value));
 
-            this.data = value;
-            this.index = -1;
+            data = value;
+            index = -1;
         }
 
         public string Current
         {
             get
             {
-                if (this.index == -1)
+                if (index == -1)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.index >= this.data.Length)
+                if (index >= data.Length)
                 {
                     throw new InvalidOperationException();
                 }
-                return this.currentElement;
+                return currentElement;
             }
         }
 
@@ -64,55 +64,55 @@ namespace CommandLine
         {
             get
             {
-                if (this.index == -1)
+                if (index == -1)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.index > this.data.Length)
+                if (index > data.Length)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.IsLast)
+                if (IsLast)
                 {
                     return null;
                 }
-                return this.data.Substring(this.index + 1, 1);
+                return data.Substring(index + 1, 1);
             }
         }
 
         public bool IsLast
         {
-            get { return this.index == this.data.Length - 1; }
+            get { return index == data.Length - 1; }
         }
 
         public void Reset()
         {
-            this.index = -1;
+            index = -1;
         }
 
         public bool MoveNext()
         {
-            if (this.index < (this.data.Length - 1))
+            if (index < (data.Length - 1))
             {
-                this.index++;
-                this.currentElement = this.data.Substring(this.index, 1);
+                index++;
+                currentElement = data.Substring(index, 1);
                 return true;
             }
-            this.index = this.data.Length;
+            index = data.Length;
             return false;
         }
 
         public string GetRemainingFromNext()
         {
-            if (this.index == -1)
+            if (index == -1)
             {
                 throw new InvalidOperationException();
             }
-            if (this.index > this.data.Length)
+            if (index > data.Length)
             {
                 throw new InvalidOperationException();
             }
-            return this.data.Substring(index + 1);
+            return data.Substring(index + 1);
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Core/IOptionMap.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/IOptionMap.cs
@@ -28,7 +28,7 @@
 
 namespace CommandLine
 {
-    interface IOptionMap
+    internal interface IOptionMap
     {
         OptionInfo this[string key] { get; set; }
 

--- a/src/SQLQueryStress/CommandLineParser/Core/IStringEnumerator.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/IStringEnumerator.cs
@@ -28,7 +28,7 @@
 
 namespace CommandLine
 {
-    interface IStringEnumerator
+    internal interface IStringEnumerator
     {
         bool MoveNext();
         string GetRemainingFromNext();

--- a/src/SQLQueryStress/CommandLineParser/Core/LongOptionParser.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/LongOptionParser.cs
@@ -28,7 +28,7 @@
 
 namespace CommandLine
 {
-    sealed class LongOptionParser : ArgumentParser
+    internal sealed class LongOptionParser : ArgumentParser
     {
         public sealed override ParserState Parse(IStringEnumerator argumentEnumerator, IOptionMap map, object options)
         {

--- a/src/SQLQueryStress/CommandLineParser/Core/OptionGroupParser.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/OptionGroupParser.cs
@@ -28,7 +28,7 @@
 
 namespace CommandLine
 {
-    sealed class OptionGroupParser : ArgumentParser
+    internal sealed class OptionGroupParser : ArgumentParser
     {
         public sealed override ParserState Parse(IStringEnumerator argumentEnumerator, IOptionMap map, object options)
         {

--- a/src/SQLQueryStress/CommandLineParser/Core/OptionInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/OptionInfo.cs
@@ -33,7 +33,7 @@ namespace CommandLine
     using System.Globalization;
     using System.Reflection;
 
-    sealed class OptionInfo
+    internal sealed class OptionInfo
     {
         private readonly OptionAttribute attribute;
         private readonly FieldInfo field;
@@ -47,10 +47,10 @@ namespace CommandLine
 
         public OptionInfo(OptionAttribute attribute, FieldInfo field)
         {
-            this.required = attribute.Required;
-            this.helpText = attribute.HelpText;
-            this.shortName = attribute.ShortName;
-            this.longName = attribute.LongName;
+            required = attribute.Required;
+            helpText = attribute.HelpText;
+            shortName = attribute.ShortName;
+            longName = attribute.LongName;
             this.field = field;
             this.attribute = attribute;
         }
@@ -77,11 +77,11 @@ namespace CommandLine
         {
             if (attribute is OptionListAttribute)
             {
-                return this.SetValueList(value, options);
+                return SetValueList(value, options);
             }
             else
             {
-                return this.SetValueScalar(value, options);
+                return SetValueScalar(value, options);
             }
         }
 
@@ -89,18 +89,18 @@ namespace CommandLine
         {
             try
             {
-                if (this.field.FieldType.IsEnum)
+                if (field.FieldType.IsEnum)
                 {
-                    lock (this.setValueLock)
+                    lock (setValueLock)
                     {
-                        this.field.SetValue(options, Enum.Parse(this.field.FieldType, value, true));
+                        field.SetValue(options, Enum.Parse(field.FieldType, value, true));
                     }
                 }
                 else
                 {
-                    lock (this.setValueLock)
+                    lock (setValueLock)
                     {
-                        this.field.SetValue(options, Convert.ChangeType(value, this.field.FieldType, CultureInfo.InvariantCulture));
+                        field.SetValue(options, Convert.ChangeType(value, field.FieldType, CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -121,20 +121,20 @@ namespace CommandLine
 
         public bool SetValue(bool value, object options)
         {
-            lock (this.setValueLock)
+            lock (setValueLock)
             {
-                this.field.SetValue(options, value);
+                field.SetValue(options, value);
                 return true;
             }
         }
 
         public bool SetValueList(string value, object options)
         {
-            lock (this.setValueLock)
+            lock (setValueLock)
             {
                 field.SetValue(options, new List<string>());
                 IList<string> fieldRef = (IList<string>)field.GetValue(options);
-                string[] values = value.Split(((OptionListAttribute)this.attribute).Separator);
+                string[] values = value.Split(((OptionListAttribute)attribute).Separator);
                 for (int i = 0; i < values.Length; i++)
                 {
                     fieldRef.Add(values[i]);
@@ -145,38 +145,38 @@ namespace CommandLine
 
         public string ShortName
         {
-            get { return this.shortName; }
+            get { return shortName; }
         }
 
         public string LongName
         {
-            get { return this.longName; }
+            get { return longName; }
         }
 
         public bool Required
         {
-            get { return this.required; }
+            get { return required; }
         }
 
         public string HelpText
         {
-            get { return this.helpText; }
+            get { return helpText; }
         }
 
         public bool IsBoolean
         {
-            get { return this.field.FieldType == typeof(bool); }
+            get { return field.FieldType == typeof(bool); }
         }
 
         public bool IsDefined
         {
-            get { return this.isDefined; }
-            set { this.isDefined = value; }
+            get { return isDefined; }
+            set { isDefined = value; }
         }
 
         public bool HasBothNames
         {
-            get { return (this.shortName != null && this.longName != null); }
+            get { return (shortName != null && longName != null); }
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Core/OptionInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/OptionInfo.cs
@@ -37,13 +37,13 @@ namespace CommandLine
     {
         private readonly OptionAttribute attribute;
         private readonly FieldInfo field;
-        private bool required;
-        private string helpText;
+        private readonly bool required;
+        private readonly string helpText;
         private bool isDefined;
-        private string shortName;
-        private string longName;
-        
-        private object setValueLock = new object();
+        private readonly string shortName;
+        private readonly string longName;
+
+        private readonly object setValueLock = new object();
 
         public OptionInfo(OptionAttribute attribute, FieldInfo field)
         {

--- a/src/SQLQueryStress/CommandLineParser/Core/OptionMap.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/OptionMap.cs
@@ -30,15 +30,15 @@ namespace CommandLine
 {
     using System.Collections.Generic;
 
-    sealed class OptionMap : IOptionMap
+    internal sealed class OptionMap : IOptionMap
     {
         private readonly Dictionary<string, string> names;
         private readonly Dictionary<string, OptionInfo> map;
 
         public OptionMap(int capacity)
         {
-            this.names = new Dictionary<string, string>(capacity);
-            this.map = new Dictionary<string, OptionInfo>(capacity * 2);
+            names = new Dictionary<string, string>(capacity);
+            map = new Dictionary<string, OptionInfo>(capacity * 2);
         }
 
         public OptionInfo this[string key]
@@ -46,34 +46,33 @@ namespace CommandLine
             get
             {
                 OptionInfo option = null;
-                if (this.map.ContainsKey(key))
+                if (map.ContainsKey(key))
                 {
-                    option = this.map[key];
+                    option = map[key];
                 }
                 else
                 {
-                    string optionKey = null;
-                    if (this.names.ContainsKey(key))
+                    if (names.ContainsKey(key))
                     {
-                        optionKey = this.names[key];
-                        option = this.map[optionKey];
+                        string optionKey = names[key];
+                        option = map[optionKey];
                     }
                 }
                 return option;
             }
             set
             {
-                this.map[key] = value;
+                map[key] = value;
                 if (value.HasBothNames)
                 {
-                    this.names[value.LongName] = value.ShortName;
+                    names[value.LongName] = value.ShortName;
                 }
             }
         }
 
         public bool EnforceRules()
         {
-            foreach (OptionInfo option in this.map.Values)
+            foreach (OptionInfo option in map.Values)
             {
                 if (option.Required && !option.IsDefined)
                 {

--- a/src/SQLQueryStress/CommandLineParser/Core/OptionMap.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/OptionMap.cs
@@ -32,8 +32,8 @@ namespace CommandLine
 
     sealed class OptionMap : IOptionMap
     {
-        private Dictionary<string, string> names;
-        private Dictionary<string, OptionInfo> map;
+        private readonly Dictionary<string, string> names;
+        private readonly Dictionary<string, OptionInfo> map;
 
         public OptionMap(int capacity)
         {

--- a/src/SQLQueryStress/CommandLineParser/Core/PairT.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/PairT.cs
@@ -28,7 +28,7 @@
 
 namespace CommandLine
 {
-    sealed class Pair<TLeft, TRight>
+    internal sealed class Pair<TLeft, TRight>
     {
         private readonly TLeft left;
         private readonly TRight right;
@@ -41,12 +41,12 @@ namespace CommandLine
 
         public TLeft Left
         {
-            get { return this.left; }
+            get { return left; }
         }
 
         public TRight Right
         {
-            get { return this.right; }
+            get { return right; }
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Core/ParserState.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/ParserState.cs
@@ -31,10 +31,10 @@ namespace CommandLine
     using System;
 
     [Flags]
-    enum ParserState : ushort
+    internal enum ParserState : ushort
     {
-        Success             = 0x01,
-        Failure             = 0x02,
-        MoveOnNextElement   = 0x04
+        Success = 0x01,
+        Failure = 0x02,
+        MoveOnNextElement = 0x04
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Core/StringEnumeratorEx.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/StringEnumeratorEx.cs
@@ -32,13 +32,13 @@ namespace CommandLine
 
     sealed class StringEnumeratorEx : IStringEnumerator
     {
-        private string[] data;
+        private readonly string[] data;
         private int index;
-        private int endIndex;
+        private readonly int endIndex;
 
         public StringEnumeratorEx(string[] value)
         {
-            Validator.CheckIsNull(value, "value");
+            Validator.CheckIsNull(value, nameof(value));
 
             this.data = value;
             this.index = -1;

--- a/src/SQLQueryStress/CommandLineParser/Core/StringEnumeratorEx.cs
+++ b/src/SQLQueryStress/CommandLineParser/Core/StringEnumeratorEx.cs
@@ -30,7 +30,7 @@ namespace CommandLine
 {
     using System;
 
-    sealed class StringEnumeratorEx : IStringEnumerator
+    internal sealed class StringEnumeratorEx : IStringEnumerator
     {
         private readonly string[] data;
         private int index;
@@ -40,24 +40,24 @@ namespace CommandLine
         {
             Validator.CheckIsNull(value, nameof(value));
 
-            this.data = value;
-            this.index = -1;
-            this.endIndex = value.Length;
+            data = value;
+            index = -1;
+            endIndex = value.Length;
         }
 
         public string Current
         {
             get
             {
-                if (this.index == -1)
+                if (index == -1)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.index >= this.endIndex)
+                if (index >= endIndex)
                 {
                     throw new InvalidOperationException();
                 }
-                return this.data[this.index];
+                return data[index];
             }
         }
 
@@ -65,38 +65,38 @@ namespace CommandLine
         {
             get
             {
-                if (this.index == -1)
+                if (index == -1)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.index > this.endIndex)
+                if (index > endIndex)
                 {
                     throw new InvalidOperationException();
                 }
-                if (this.IsLast)
+                if (IsLast)
                 {
                     return null;
                 }
-                return this.data[this.index + 1];
+                return data[index + 1];
             }
         }
 
         public bool IsLast
         {
-            get { return this.index == this.endIndex - 1; }
+            get { return index == endIndex - 1; }
         }
 
         public void Reset()
         {
-            this.index = -1;
+            index = -1;
         }
 
         public bool MoveNext()
         {
-            if (this.index < this.endIndex)
+            if (index < endIndex)
             {
-                this.index++;
-                return this.index < this.endIndex;
+                index++;
+                return index < endIndex;
             }
             return false;
         }

--- a/src/SQLQueryStress/CommandLineParser/Exceptions/IncompatibleTypesException.cs
+++ b/src/SQLQueryStress/CommandLineParser/Exceptions/IncompatibleTypesException.cs
@@ -56,7 +56,7 @@ namespace CommandLine
         {
         }
 
-        internal IncompatibleTypesException(SerializationInfo info, StreamingContext context)
+        private IncompatibleTypesException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/SQLQueryStress/CommandLineParser/Exceptions/ParserException.cs
+++ b/src/SQLQueryStress/CommandLineParser/Exceptions/ParserException.cs
@@ -52,7 +52,7 @@ namespace CommandLine
         {
         }
 
-        internal ParserException(SerializationInfo info, StreamingContext context)
+        private ParserException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/SQLQueryStress/CommandLineParser/Parser.cs
+++ b/src/SQLQueryStress/CommandLineParser/Parser.cs
@@ -39,7 +39,7 @@ namespace CommandLine
     [Obsolete("Parser is obsolete, instead use CommandLineParser.")]
     public static class Parser
     {
-        private static ICommandLineParser parser = new CommandLineParser();
+        private static readonly ICommandLineParser parser = new CommandLineParser();
 
         /// <summary>
         /// Parses a <see cref="System.String"/> array of command line arguments,
@@ -74,6 +74,6 @@ namespace CommandLine
         public static bool ParseArguments(string[] args, object options, TextWriter helpWriter)
         {
             return parser.ParseArguments(args, options, helpWriter);
-        } 
-   }
+        }
+    }
 }

--- a/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
@@ -95,7 +95,7 @@ namespace CommandLine.Text
             this.isSymbolUpper = isSymbolUpper; //this.symbol = symbol;
             this.author = author;
             this.years = years;
-            this.builder = new StringBuilder
+            builder = new StringBuilder
                     (CopyrightWord.Length + author.Length + (4 * years.Length) + extraLength);
         }
 
@@ -105,9 +105,9 @@ namespace CommandLine.Text
         /// <returns>The <see cref="System.String"/> that contains the copyright informations.</returns>
         public override string ToString()
         {
-            builder.Append(this.CopyrightWord);
+            builder.Append(CopyrightWord);
             builder.Append(' ');
-            if (this.isSymbolUpper)
+            if (isSymbolUpper)
             {
                 builder.Append(symbolUpper);
             }
@@ -116,9 +116,9 @@ namespace CommandLine.Text
                 builder.Append(symbolLower);
             }
             builder.Append(' ');
-            builder.Append(this.FormatYears(years));
+            builder.Append(FormatYears(years));
             builder.Append(' ');
-            builder.Append(this.author);
+            builder.Append(author);
             return builder.ToString();
         }
 

--- a/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
@@ -40,10 +40,10 @@ namespace CommandLine.Text
         private readonly bool isSymbolUpper;
         private readonly int[] years;
         private readonly string author;
-        private static readonly string defaultCopyrightWord = "Copyright";
-        private static readonly string symbolLower = "(c)";
-        private static readonly string symbolUpper = "(C)";
-        private StringBuilder builder;
+        private const string defaultCopyrightWord = "Copyright";
+        private const string symbolLower = "(c)";
+        private const string symbolUpper = "(C)";
+        private readonly StringBuilder builder;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Text.CopyrightInfo"/> class.
@@ -88,8 +88,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when parameter <paramref name="years"/> is not supplied.</exception>
         public CopyrightInfo(bool isSymbolUpper, string author, params int[] years)
         {
-            Validator.CheckIsNullOrEmpty(author, "author");
-            Validator.CheckZeroLength(years, "years");
+            Validator.CheckIsNullOrEmpty(author, nameof(author));
+            Validator.CheckZeroLength(years, nameof(years));
 
             const int extraLength = 10;
             this.isSymbolUpper = isSymbolUpper; //this.symbol = symbol;

--- a/src/SQLQueryStress/CommandLineParser/Text/HeadingInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/HeadingInfo.cs
@@ -72,14 +72,14 @@ namespace CommandLine.Text
         /// <returns>The <see cref="System.String"/> that contains the heading informations.</returns>
         public override string ToString()
         {
-            bool isVersionNull = string.IsNullOrEmpty(this.version);
-            StringBuilder builder = new StringBuilder(this.programName.Length +
+            bool isVersionNull = string.IsNullOrEmpty(version);
+            StringBuilder builder = new StringBuilder(programName.Length +
                                 (!isVersionNull ? version.Length + 1 : 0));
-            builder.Append(this.programName);
+            builder.Append(programName);
             if (!isVersionNull)
             {
                 builder.Append(' ');
-                builder.Append(this.version);
+                builder.Append(version);
             }
             return builder.ToString();
         }
@@ -107,8 +107,8 @@ namespace CommandLine.Text
             Validator.CheckIsNullOrEmpty(message, nameof(message));
             Validator.CheckIsNull(writer, nameof(writer));
 
-            StringBuilder builder = new StringBuilder(this.programName.Length + message.Length + 2);
-            builder.Append(this.programName);
+            StringBuilder builder = new StringBuilder(programName.Length + message.Length + 2);
+            builder.Append(programName);
             builder.Append(": ");
             builder.Append(message);
             writer.WriteLine(builder.ToString());
@@ -122,7 +122,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="message"/> is null or empty string.</exception>
         public void WriteMessage(string message)
         {
-            this.WriteMessage(message, System.Console.Out);
+            WriteMessage(message, System.Console.Out);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="message"/> is null or empty string.</exception>
         public void WriteError(string message)
         {
-            this.WriteMessage(message, System.Console.Error);
+            WriteMessage(message, System.Console.Error);
         }
     }
 }

--- a/src/SQLQueryStress/CommandLineParser/Text/HeadingInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/HeadingInfo.cs
@@ -60,7 +60,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="programName"/> is null or empty string.</exception>
         public HeadingInfo(string programName, string version)
         {
-            Validator.CheckIsNullOrEmpty(programName, "programName");
+            Validator.CheckIsNullOrEmpty(programName, nameof(programName));
 
             this.programName = programName;
             this.version = version;
@@ -74,7 +74,7 @@ namespace CommandLine.Text
         {
             bool isVersionNull = string.IsNullOrEmpty(this.version);
             StringBuilder builder = new StringBuilder(this.programName.Length +
-                                (!isVersionNull ? version.Length + 1: 0));
+                                (!isVersionNull ? version.Length + 1 : 0));
             builder.Append(this.programName);
             if (!isVersionNull)
             {
@@ -104,8 +104,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="writer"/> is null.</exception>
         public void WriteMessage(string message, TextWriter writer)
         {
-            Validator.CheckIsNullOrEmpty(message, "message");
-            Validator.CheckIsNull(writer, "writer");
+            Validator.CheckIsNullOrEmpty(message, nameof(message));
+            Validator.CheckIsNull(writer, nameof(writer));
 
             StringBuilder builder = new StringBuilder(this.programName.Length + message.Length + 2);
             builder.Append(this.programName);

--- a/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
@@ -44,9 +44,9 @@ namespace CommandLine.Text
         private const int builderCapacity = 128;
         private readonly string heading;
         private string copyright;
-        private StringBuilder preOptionsHelp;
+        private readonly StringBuilder preOptionsHelp;
         private StringBuilder optionsHelp;
-        private static readonly string defaultRequiredWord = "Required.";
+        private const string defaultRequiredWord = "Required.";
         #endregion
 
         private HelpText()
@@ -64,7 +64,7 @@ namespace CommandLine.Text
         public HelpText(string heading)
             : this()
         {
-            Validator.CheckIsNullOrEmpty(heading, "heading");
+            Validator.CheckIsNullOrEmpty(heading, nameof(heading));
 
             this.heading = heading;
         }
@@ -73,13 +73,10 @@ namespace CommandLine.Text
         /// Sets the copyright information string.
         /// You can directly assign a <see cref="CommandLine.Text.CopyrightInfo"/> instance.
         /// </summary>
-        public string Copyright
+        public void SetCopyright(string value)
         {
-            set
-            {
-                Validator.CheckIsNullOrEmpty(value, "value");
-                this.copyright = value;
-            }
+            Validator.CheckIsNullOrEmpty(value, nameof(value));
+            this.copyright = value;
         }
 
         /// <summary>
@@ -111,8 +108,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="requiredWord"/> is null or empty string.</exception>
         public void AddOptions(object options, string requiredWord)
         {
-            Validator.CheckIsNull(options, "options");
-            Validator.CheckIsNullOrEmpty(requiredWord, "requiredWord");
+            Validator.CheckIsNull(options, nameof(options));
+            Validator.CheckIsNullOrEmpty(requiredWord, nameof(requiredWord));
 
             IList<BaseOptionAttribute> optionList =
                                 ReflectionUtil.RetrieveFieldAttributeList<BaseOptionAttribute>(options);
@@ -212,7 +209,7 @@ namespace CommandLine.Text
         private static void AddLine(StringBuilder builder, string value)
         {
             //Validator.CheckIsNullOrEmpty(value, "value");
-            Validator.CheckIsNull(value, "value");
+            Validator.CheckIsNull(value, nameof(value));
 
             if (builder.Length > 0)
             {

--- a/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
@@ -51,7 +51,7 @@ namespace CommandLine.Text
 
         private HelpText()
         {
-            this.preOptionsHelp = new StringBuilder(builderCapacity);
+            preOptionsHelp = new StringBuilder(builderCapacity);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace CommandLine.Text
         public void SetCopyright(string value)
         {
             Validator.CheckIsNullOrEmpty(value, nameof(value));
-            this.copyright = value;
+            copyright = value;
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="value"/> is null or empty string.</exception>
         public void AddPreOptionsLine(string value)
         {
-            AddLine(this.preOptionsHelp, value);
+            AddLine(preOptionsHelp, value);
         }
 
         /// <summary>
@@ -127,11 +127,11 @@ namespace CommandLine.Text
             }
 
             int maxLength = GetMaxLength(optionList);
-            this.optionsHelp = new StringBuilder(builderCapacity);
+            optionsHelp = new StringBuilder(builderCapacity);
 
             foreach (BaseOptionAttribute option in optionList)
             {
-                this.optionsHelp.Append("  ");
+                optionsHelp.Append("  ");
                 StringBuilder optionName = new StringBuilder(maxLength);
                 if (option.HasShortName)
                 {
@@ -147,20 +147,20 @@ namespace CommandLine.Text
                 }
                 if (optionName.Length < maxLength)
                 {
-                    this.optionsHelp.Append(optionName.ToString().PadRight(maxLength));
+                    optionsHelp.Append(optionName.ToString().PadRight(maxLength));
                 }
                 else
                 {
-                    this.optionsHelp.Append(optionName.ToString());
+                    optionsHelp.Append(optionName.ToString());
                 }
-                this.optionsHelp.Append("\t");
+                optionsHelp.Append("\t");
                 if (option.Required)
                 {
-                    this.optionsHelp.Append(requiredWord);
-                    this.optionsHelp.Append(' ');
+                    optionsHelp.Append(requiredWord);
+                    optionsHelp.Append(' ');
                 }
-                this.optionsHelp.Append(option.HelpText);
-                this.optionsHelp.Append(Environment.NewLine);
+                optionsHelp.Append(option.HelpText);
+                optionsHelp.Append(Environment.NewLine);
             }
         }
 
@@ -171,26 +171,26 @@ namespace CommandLine.Text
         public override string ToString()
         {
             const int extraLength = 10;
-            StringBuilder builder = new StringBuilder(this.heading.Length +
-                                GetLength(this.copyright) + GetLength(this.preOptionsHelp) +
-                                GetLength(this.optionsHelp) + extraLength);
+            StringBuilder builder = new StringBuilder(heading.Length +
+                                GetLength(copyright) + GetLength(preOptionsHelp) +
+                                GetLength(optionsHelp) + extraLength);
 
-            builder.Append(this.heading);
-            if (!string.IsNullOrEmpty(this.copyright))
+            builder.Append(heading);
+            if (!string.IsNullOrEmpty(copyright))
             {
                 builder.Append(Environment.NewLine);
-                builder.Append(this.copyright);
+                builder.Append(copyright);
             }
-            if (this.preOptionsHelp.Length > 0)
+            if (preOptionsHelp.Length > 0)
             {
                 builder.Append(Environment.NewLine);
-                builder.Append(this.preOptionsHelp.ToString());
+                builder.Append(preOptionsHelp.ToString());
             }
-            if (this.optionsHelp != null && this.optionsHelp.Length > 0)
+            if (optionsHelp != null && optionsHelp.Length > 0)
             {
                 builder.Append(Environment.NewLine);
                 builder.Append(Environment.NewLine);
-                builder.Append(this.optionsHelp.ToString());
+                builder.Append(optionsHelp.ToString());
             }
 
             return builder.ToString();

--- a/src/SQLQueryStress/CommandLineParser/Util/ReflectionUtil.cs
+++ b/src/SQLQueryStress/CommandLineParser/Util/ReflectionUtil.cs
@@ -32,7 +32,7 @@ namespace CommandLine
     using System.Collections.Generic;
     using System.Reflection;
 
-    static class ReflectionUtil
+    internal static class ReflectionUtil
     {
         public static IList<Pair<FieldInfo, TAttribute>> RetrieveFieldList<TAttribute>(object target)
                 where TAttribute : Attribute

--- a/src/SQLQueryStress/CommandLineParser/Util/Validator.cs
+++ b/src/SQLQueryStress/CommandLineParser/Util/Validator.cs
@@ -30,7 +30,7 @@ namespace CommandLine
 {
     using System;
 
-    static class Validator
+    internal static class Validator
     {
         public static void CheckIsNull<T>(T value, string paramName)
                 where T : class

--- a/src/SQLQueryStress/ConnectionInfo.cs
+++ b/src/SQLQueryStress/ConnectionInfo.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SQLQueryStress
 {
@@ -32,7 +28,6 @@ namespace SQLQueryStress
         public readonly bool EnablePooling;
         [DataMember]
         public readonly int MaxPoolSize;
-
 
         public ConnectionInfo()
         {

--- a/src/SQLQueryStress/ConnectionInfo.cs
+++ b/src/SQLQueryStress/ConnectionInfo.cs
@@ -27,11 +27,11 @@ namespace SQLQueryStress
         public ApplicationIntent ApplicationIntent;
 
         [DataMember]
-        public int ConnectTimeout;
+        public readonly int ConnectTimeout;
         [DataMember]
-        public bool EnablePooling;
+        public readonly bool EnablePooling;
         [DataMember]
-        public int MaxPoolSize; 
+        public readonly int MaxPoolSize;
 
 
         public ConnectionInfo()
@@ -44,7 +44,7 @@ namespace SQLQueryStress
             Database = "";
             ConnectTimeout = 0;
             MaxPoolSize = 0;
-            EnablePooling = true; 
+            EnablePooling = true;
         }
 
         public ConnectionInfo(int connectTimeout, bool enablePooling, int maxPoolSize) : this()
@@ -58,7 +58,7 @@ namespace SQLQueryStress
         {
             get
             {
-                var build = new SqlConnectionStringBuilder { DataSource = Server, IntegratedSecurity = IntegratedAuth, ApplicationName = "SQLQueryStress", ApplicationIntent = ApplicationIntent };
+                SqlConnectionStringBuilder build = new SqlConnectionStringBuilder { DataSource = Server, IntegratedSecurity = IntegratedAuth, ApplicationName = "SQLQueryStress", ApplicationIntent = ApplicationIntent };
                 if (!IntegratedAuth)
                 {
                     build.UserID = Login;
@@ -68,7 +68,8 @@ namespace SQLQueryStress
                 if (Database.Length > 0)
                     build.InitialCatalog = Database;
 
-                if (ConnectTimeout != 0){
+                if (ConnectTimeout != 0)
+                {
                     build.ConnectTimeout = ConnectTimeout;
                 }
 
@@ -88,7 +89,7 @@ namespace SQLQueryStress
 
         public object Clone()
         {
-            var newConnInfo = new ConnectionInfo();
+            ConnectionInfo newConnInfo = new ConnectionInfo();
             CopyTo(newConnInfo);
 
             return newConnInfo;
@@ -108,16 +109,18 @@ namespace SQLQueryStress
 
         public bool TestConnection()
         {
-            if ((Server == "") || ((IntegratedAuth == false) && (Login == "" || Password == "")))
+            if (string.IsNullOrEmpty(Server) || ((IntegratedAuth == false) && (string.IsNullOrEmpty(Login) || string.IsNullOrEmpty(Password))))
+            {
                 return false;
+            }
 
-            using (var conn = new SqlConnection(ConnectionString))
+            using (SqlConnection conn = new SqlConnection(ConnectionString))
             {
                 try
                 {
                     conn.Open();
                 }
-                catch (Exception exc)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/src/SQLQueryStress/DataViewer.cs
+++ b/src/SQLQueryStress/DataViewer.cs
@@ -21,7 +21,7 @@ namespace SQLQueryStress
         {
             dataGridView1.DataSource = DataView;
 
-            var columnWidth = (dataGridView1.Width - 41) / DataView.Columns.Count;
+            int columnWidth = (dataGridView1.Width - 41) / DataView.Columns.Count;
 
             foreach (DataGridViewColumn col in dataGridView1.Columns)
                 col.Width = columnWidth;

--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -155,7 +155,7 @@ namespace SQLQueryStress
             this.cancel_button.TabIndex = 3;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
-            this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
+            this.cancel_button.Click += new System.EventHandler(this.Cancel_button_Click);
             // 
             // test_button
             // 
@@ -167,7 +167,7 @@ namespace SQLQueryStress
             this.test_button.TabIndex = 5;
             this.test_button.Text = "Test Connection";
             this.test_button.UseVisualStyleBackColor = true;
-            this.test_button.Click += new System.EventHandler(this.test_button_Click);
+            this.test_button.Click += new System.EventHandler(this.Test_button_Click);
             // 
             // ok_button
             // 
@@ -179,7 +179,7 @@ namespace SQLQueryStress
             this.ok_button.TabIndex = 2;
             this.ok_button.Text = "OK";
             this.ok_button.UseVisualStyleBackColor = true;
-            this.ok_button.Click += new System.EventHandler(this.ok_button_Click);
+            this.ok_button.Click += new System.EventHandler(this.Ok_button_Click);
             // 
             // db_comboBox
             // 
@@ -249,7 +249,7 @@ namespace SQLQueryStress
             this.appintent_check.TabIndex = 13;
             this.appintent_check.Text = "Application Intent";
             this.appintent_check.UseVisualStyleBackColor = true;
-            this.appintent_check.CheckedChanged += new System.EventHandler(this.appintent_check_CheckedChanged);
+            this.appintent_check.CheckedChanged += new System.EventHandler(this.Appintent_check_CheckedChanged);
             // 
             // groupBox2
             // 
@@ -287,7 +287,7 @@ namespace SQLQueryStress
             this.pm_test_button.TabIndex = 5;
             this.pm_test_button.Text = "Test Connection";
             this.pm_test_button.UseVisualStyleBackColor = true;
-            this.pm_test_button.Click += new System.EventHandler(this.pm_test_button_Click);
+            this.pm_test_button.Click += new System.EventHandler(this.Pm_test_button_Click);
             // 
             // shareSettings_checkBox
             // 
@@ -302,7 +302,7 @@ namespace SQLQueryStress
             this.shareSettings_checkBox.TabIndex = 13;
             this.shareSettings_checkBox.Text = "Share Connection Settings";
             this.shareSettings_checkBox.UseVisualStyleBackColor = true;
-            this.shareSettings_checkBox.CheckedChanged += new System.EventHandler(this.shareSettings_checkBox_CheckedChanged);
+            this.shareSettings_checkBox.CheckedChanged += new System.EventHandler(this.ShareSettings_checkBox_CheckedChanged);
             // 
             // pm_db_comboBox
             // 
@@ -434,7 +434,7 @@ namespace SQLQueryStress
             this.pm_appintent_check.TabIndex = 15;
             this.pm_appintent_check.Text = "Application Intent";
             this.pm_appintent_check.UseVisualStyleBackColor = true;
-            this.pm_appintent_check.CheckedChanged += new System.EventHandler(this.pm_appintent_check_CheckedChanged);
+            this.pm_appintent_check.CheckedChanged += new System.EventHandler(this.Pm_appintent_check_CheckedChanged);
             // 
             // DatabaseSelect
             // 

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -19,15 +19,15 @@ namespace SQLQueryStress
         public DatabaseSelect(QueryStressSettings settings)
         {
             _settings = settings;
-            _localMainConnectionInfo = (ConnectionInfo) settings.MainDbConnectionInfo.Clone();
+            _localMainConnectionInfo = (ConnectionInfo)settings.MainDbConnectionInfo.Clone();
 
             if (settings.ShareDbSettings)
             {
-                _localParamConnectionInfo = (ConnectionInfo) settings.MainDbConnectionInfo.Clone();
+                _localParamConnectionInfo = (ConnectionInfo)settings.MainDbConnectionInfo.Clone();
             }
             else
             {
-                _localParamConnectionInfo = (ConnectionInfo) settings.ParamDbConnectionInfo.Clone();
+                _localParamConnectionInfo = (ConnectionInfo)settings.ParamDbConnectionInfo.Clone();
             }
 
             InitializeComponent();
@@ -94,15 +94,15 @@ namespace SQLQueryStress
 
             shareSettings_checkBox.Checked = settings.ShareDbSettings;
 
-            authentication_comboBox.SelectedIndexChanged += authentication_comboBox_SelectedIndexChanged;
-            pm_authentication_comboBox.SelectedIndexChanged += pm_authentication_comboBox_SelectedIndexChanged;
+            authentication_comboBox.SelectedIndexChanged += Authentication_comboBox_SelectedIndexChanged;
+            pm_authentication_comboBox.SelectedIndexChanged += Pm_authentication_comboBox_SelectedIndexChanged;
 
             db_comboBox.Enter += Db_comboBox_Enter;
             db_comboBox.Leave += Db_comboBox_Leave;
 
             pm_db_comboBox.Enter += Db_comboBox_Enter;
             pm_db_comboBox.Leave += Db_comboBox_Leave;
-            
+
             server_textBox.KeyDown += Server_textBox_KeyDown;
             server_textBox.TextChanged += Server_textBox_TextChanged;
 
@@ -121,7 +121,7 @@ namespace SQLQueryStress
 
         private void Db_comboBox_Leave(object sender, EventArgs e)
         {
-            var cbSender = ((ComboBox)sender);
+            ComboBox cbSender = ((ComboBox)sender);
             if ((cbSender.SelectedValue == null || cbSender.Text != cbSender.SelectedItem.ToString()) && cbSender.Items.Contains(cbSender.Text))
             {
                 cbSender.SelectedItem = cbSender.Text;
@@ -130,8 +130,8 @@ namespace SQLQueryStress
 
         private void Db_comboBox_Enter(object sender, EventArgs e)
         {
-            var cbSender = ((ComboBox)sender);
-            var _prevSelectedValue = cbSender.SelectedValue != null ? cbSender.SelectedValue.ToString() : string.Empty;
+            ComboBox cbSender = ((ComboBox)sender);
+            string _prevSelectedValue = cbSender.SelectedValue != null ? cbSender.SelectedValue.ToString() : string.Empty;
             ReloadDatabaseList(sender);
 
             if (cbSender.Items.Contains(_prevSelectedValue))
@@ -142,8 +142,8 @@ namespace SQLQueryStress
 
         private void ReloadDatabaseList(object objDatabaseParam)
         {
-            var dbComboboxParam = (ComboBox)objDatabaseParam;
-            var selectedComboBoxItem = (string)dbComboboxParam.SelectedItem;
+            ComboBox dbComboboxParam = (ComboBox)objDatabaseParam;
+            string selectedComboBoxItem = (string)dbComboboxParam.SelectedItem;
             string connectionString;
             if (dbComboboxParam == db_comboBox)
             {
@@ -152,23 +152,23 @@ namespace SQLQueryStress
             }
             else
             {
-                pm_saveLocalSettings();
+                Pm_saveLocalSettings();
                 connectionString = _localParamConnectionInfo.ConnectionString;
             }
 
-            var sql = "SELECT databases.name FROM sys.databases WHERE databases.state = 0 ORDER BY databases.name";
+            string sql = "SELECT databases.name FROM sys.databases WHERE databases.state = 0 ORDER BY databases.name";
 
-            using (var conn = new SqlConnection(connectionString))
+            using (SqlConnection conn = new SqlConnection(connectionString))
             {
-                var comm = new SqlCommand(sql, conn);
+                SqlCommand comm = new SqlCommand(sql, conn);
 
-                var databases = new List<string>();
+                List<string> databases = new List<string>();
 
                 try
                 {
                     conn.Open();
 
-                    var reader = comm.ExecuteReader();
+                    SqlDataReader reader = comm.ExecuteReader();
 
                     while (reader.Read())
                     {
@@ -215,7 +215,7 @@ namespace SQLQueryStress
             }
         }
 
-        private void authentication_comboBox_SelectedIndexChanged(object sender, EventArgs e)
+        private void Authentication_comboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (authentication_comboBox.SelectedIndex == 0)
             {
@@ -229,15 +229,15 @@ namespace SQLQueryStress
             }
         }
 
-        private void cancel_button_Click(object sender, EventArgs e)
+        private void Cancel_button_Click(object sender, EventArgs e)
         {
             Dispose();
         }
 
-        private void ok_button_Click(object sender, EventArgs e)
+        private void Ok_button_Click(object sender, EventArgs e)
         {
             SaveLocalSettings();
-            pm_saveLocalSettings();
+            Pm_saveLocalSettings();
 
             _localMainConnectionInfo.CopyTo(_settings.MainDbConnectionInfo);
             _localParamConnectionInfo.CopyTo(_settings.ParamDbConnectionInfo);
@@ -246,7 +246,7 @@ namespace SQLQueryStress
             Dispose();
         }
 
-        private void pm_authentication_comboBox_SelectedIndexChanged(object sender, EventArgs e)
+        private void Pm_authentication_comboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (pm_authentication_comboBox.SelectedIndex == 0)
             {
@@ -260,7 +260,7 @@ namespace SQLQueryStress
             }
         }
 
-        private void pm_saveLocalSettings()
+        private void Pm_saveLocalSettings()
         {
             if (!shareSettings_checkBox.Checked)
             {
@@ -282,9 +282,7 @@ namespace SQLQueryStress
 
                 if (pm_appintent_check.Checked)
                 {
-                    ApplicationIntent applicationIntent;
-
-                    Enum.TryParse<ApplicationIntent>(pm_appintent_combo.Text, out applicationIntent);
+                    _ = Enum.TryParse(pm_appintent_combo.Text, out ApplicationIntent applicationIntent);
 
                     _localParamConnectionInfo.ApplicationIntent = applicationIntent;
                 }
@@ -293,9 +291,9 @@ namespace SQLQueryStress
                 _localParamConnectionInfo = new ConnectionInfo();
         }
 
-        private void pm_test_button_Click(object sender, EventArgs e)
+        private void Pm_test_button_Click(object sender, EventArgs e)
         {
-            pm_saveLocalSettings();
+            Pm_saveLocalSettings();
 
             MessageBox.Show(_localParamConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail);
         }
@@ -316,19 +314,16 @@ namespace SQLQueryStress
                 _localMainConnectionInfo.Password = password_textBox.Text;
             }
 
-            if(appintent_check.Checked)
+            if (appintent_check.Checked)
             {
-                ApplicationIntent applicationIntent;
-
-                Enum.TryParse<ApplicationIntent>(appintent_combo.Text, out applicationIntent);
-
+                _ = Enum.TryParse(appintent_combo.Text, out ApplicationIntent applicationIntent);
                 _localMainConnectionInfo.ApplicationIntent = applicationIntent;
             }
 
             _localMainConnectionInfo.Database = db_comboBox.Text;
         }
 
-        private void shareSettings_checkBox_CheckedChanged(object sender, EventArgs e)
+        private void ShareSettings_checkBox_CheckedChanged(object sender, EventArgs e)
         {
             if (shareSettings_checkBox.Checked)
             {
@@ -354,7 +349,7 @@ namespace SQLQueryStress
             }
         }
 
-        private void test_button_Click(object sender, EventArgs e)
+        private void Test_button_Click(object sender, EventArgs e)
         {
             SaveLocalSettings();
 
@@ -362,14 +357,14 @@ namespace SQLQueryStress
         }
 
 
-        private void appintent_check_CheckedChanged(object sender, EventArgs e)
+        private void Appintent_check_CheckedChanged(object sender, EventArgs e)
         {
             appintent_combo.Enabled = appintent_check.Checked;
 
             appintent_combo.DataSource = Enum.GetValues(typeof(ApplicationIntent));
         }
 
-        private void pm_appintent_check_CheckedChanged(object sender, EventArgs e)
+        private void Pm_appintent_check_CheckedChanged(object sender, EventArgs e)
         {
             pm_appintent_combo.Enabled = pm_appintent_check.Checked;
 

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -174,9 +174,13 @@ namespace SQLQueryStress
                     {
                         databases.Add((string)reader[0]);
                     }
+
+                    comm.Dispose();
                 }
                 catch (SqlException ex)
                 {
+                    comm.Dispose();
+
                     if (ex.Number == 40615)
                         return;
                     if (ex.Number == 18456) // login failed. This helps with connecting to Azure databases
@@ -355,7 +359,6 @@ namespace SQLQueryStress
 
             MessageBox.Show(_localMainConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail);
         }
-
 
         private void Appintent_check_CheckedChanged(object sender, EventArgs e)
         {

--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -25,7 +25,7 @@ namespace SQLQueryStress
                 System.Windows.Forms.MessageBoxButtons.YesNo,
                 System.Windows.Forms.MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes)
                 {
-                    cancel_button_Click(new System.String(' ', 0), null);
+                    Cancel_button_Click(new System.String(' ', 0), null);
                 }
             }
             else
@@ -162,21 +162,21 @@ namespace SQLQueryStress
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
             this.optionsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
             this.optionsToolStripMenuItem.Text = "Options";
-            this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
+            this.optionsToolStripMenuItem.Click += new System.EventHandler(this.OptionsToolStripMenuItem_Click);
             // 
             // saveSettingsToolStripMenuItem
             // 
             this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
             this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
             this.saveSettingsToolStripMenuItem.Text = "Save Settings";
-            this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
+            this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.SaveSettingsToolStripMenuItem_Click);
             // 
             // loadSettingsToolStripMenuItem
             // 
             this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
             this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
             this.loadSettingsToolStripMenuItem.Text = "Load Settings";
-            this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
+            this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.LoadSettingsToolStripMenuItem_Click);
             // 
             // saveBenchMarkToolStripMenuItem
             // 
@@ -193,28 +193,28 @@ namespace SQLQueryStress
             this.toCsvToolStripMenuItem.Name = "toCsvToolStripMenuItem";
             this.toCsvToolStripMenuItem.Size = new System.Drawing.Size(197, 30);
             this.toCsvToolStripMenuItem.Text = "To Csv";
-            this.toCsvToolStripMenuItem.Click += new System.EventHandler(this.toCsvToolStripMenuItem_Click);
+            this.toCsvToolStripMenuItem.Click += new System.EventHandler(this.ToCsvToolStripMenuItem_Click);
             // 
             // toTextToolStripMenuItem
             // 
             this.toTextToolStripMenuItem.Name = "toTextToolStripMenuItem";
             this.toTextToolStripMenuItem.Size = new System.Drawing.Size(197, 30);
             this.toTextToolStripMenuItem.Text = "To Text";
-            this.toTextToolStripMenuItem.Click += new System.EventHandler(this.toTextToolStripMenuItem_Click);
+            this.toTextToolStripMenuItem.Click += new System.EventHandler(this.ToTextToolStripMenuItem_Click);
             // 
             // toClipboardToolStripMenuItem
             // 
             this.toClipboardToolStripMenuItem.Name = "toClipboardToolStripMenuItem";
             this.toClipboardToolStripMenuItem.Size = new System.Drawing.Size(197, 30);
             this.toClipboardToolStripMenuItem.Text = "To Clipboard";
-            this.toClipboardToolStripMenuItem.Click += new System.EventHandler(this.toClipboardToolStripMenuItem_Click);
+            this.toClipboardToolStripMenuItem.Click += new System.EventHandler(this.ToClipboardToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             this.exitToolStripMenuItem.Size = new System.Drawing.Size(225, 30);
             this.exitToolStripMenuItem.Text = "Exit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -229,7 +229,7 @@ namespace SQLQueryStress
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
             this.aboutToolStripMenuItem.Size = new System.Drawing.Size(146, 30);
             this.aboutToolStripMenuItem.Text = "About";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItem_Click);
             // 
             // go_button
             // 
@@ -242,7 +242,7 @@ namespace SQLQueryStress
             this.go_button.TabIndex = 0;
             this.go_button.Text = "GO";
             this.go_button.UseVisualStyleBackColor = true;
-            this.go_button.Click += new System.EventHandler(this.go_button_Click);
+            this.go_button.Click += new System.EventHandler(this.Go_button_Click);
             // 
             // label2
             // 
@@ -328,7 +328,7 @@ namespace SQLQueryStress
             this.cancel_button.TabIndex = 1;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
-            this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
+            this.cancel_button.Click += new System.EventHandler(this.Cancel_button_Click);
             // 
             // label4
             // 
@@ -346,9 +346,9 @@ namespace SQLQueryStress
             // 
             this.backgroundWorker1.WorkerReportsProgress = true;
             this.backgroundWorker1.WorkerSupportsCancellation = true;
-            this.backgroundWorker1.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker1_DoWork);
-            this.backgroundWorker1.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.backgroundWorker1_ProgressChanged);
-            this.backgroundWorker1.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorker1_RunWorkerCompleted);
+            this.backgroundWorker1.DoWork += new System.ComponentModel.DoWorkEventHandler(this.BackgroundWorker1_DoWork);
+            this.backgroundWorker1.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.BackgroundWorker1_ProgressChanged);
+            this.backgroundWorker1.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.BackgroundWorker1_RunWorkerCompleted);
             // 
             // label5
             // 
@@ -423,11 +423,11 @@ namespace SQLQueryStress
             this.totalExceptions_textBox.Size = new System.Drawing.Size(232, 46);
             this.totalExceptions_textBox.TabIndex = 1;
             this.totalExceptions_textBox.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.totalExceptions_textBox.Click += new System.EventHandler(this.totalExceptions_textBox_Click);
+            this.totalExceptions_textBox.Click += new System.EventHandler(this.TotalExceptions_textBox_Click);
             // 
             // mainUITimer
             // 
-            this.mainUITimer.Tick += new System.EventHandler(this.mainUITimer_Tick);
+            this.mainUITimer.Tick += new System.EventHandler(this.MainUITimer_Tick);
             // 
             // label8
             // 
@@ -470,7 +470,7 @@ namespace SQLQueryStress
             this.database_button.TabIndex = 1;
             this.database_button.Text = "Database";
             this.database_button.UseVisualStyleBackColor = true;
-            this.database_button.Click += new System.EventHandler(this.database_button_Click);
+            this.database_button.Click += new System.EventHandler(this.Database_button_Click);
             // 
             // iterationsSecond_textBox
             // 
@@ -496,7 +496,7 @@ namespace SQLQueryStress
             this.exceptions_button.TabIndex = 1;
             this.exceptions_button.Text = "...";
             this.exceptions_button.UseVisualStyleBackColor = true;
-            this.exceptions_button.Click += new System.EventHandler(this.exceptions_button_Click);
+            this.exceptions_button.Click += new System.EventHandler(this.Exceptions_button_Click);
             // 
             // label9
             // 
@@ -677,7 +677,7 @@ namespace SQLQueryStress
             this.param_button.TabIndex = 2;
             this.param_button.Text = "Parameter Substitution";
             this.param_button.UseVisualStyleBackColor = true;
-            this.param_button.Click += new System.EventHandler(this.param_button_Click);
+            this.param_button.Click += new System.EventHandler(this.Param_button_Click);
             // 
             // tableLayoutPanel4
             // 
@@ -706,7 +706,7 @@ namespace SQLQueryStress
             this.btnFreeCache.TabIndex = 1;
             this.btnFreeCache.Text = "Free Cache";
             this.btnFreeCache.UseVisualStyleBackColor = true;
-            this.btnFreeCache.Click += new System.EventHandler(this.btnFreeCache_Click);
+            this.btnFreeCache.Click += new System.EventHandler(this.BtnFreeCache_Click);
             // 
             // btnCleanBuffer
             // 
@@ -718,7 +718,7 @@ namespace SQLQueryStress
             this.btnCleanBuffer.TabIndex = 0;
             this.btnCleanBuffer.Text = "Clean Buffers";
             this.btnCleanBuffer.UseVisualStyleBackColor = true;
-            this.btnCleanBuffer.Click += new System.EventHandler(this.btnCleanBuffer_Click);
+            this.btnCleanBuffer.Click += new System.EventHandler(this.BtnCleanBuffer_Click);
             // 
             // label11
             // 

--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -298,7 +298,7 @@ namespace SQLQueryStress
             this.threads_numericUpDown.Location = new System.Drawing.Point(4, 338);
             this.threads_numericUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.threads_numericUpDown.Maximum = new decimal(new int[] {
-            200,
+            1000,
             0,
             0,
             0});

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -81,7 +81,7 @@ namespace SQLQueryStress
 
         private Guid _testGuid;
 
-        private CommandLineOptions _runParameters; 
+        private readonly CommandLineOptions _runParameters;
 
         public Form1(CommandLineOptions runParameters) : this()
         {
@@ -89,7 +89,7 @@ namespace SQLQueryStress
 
             if (string.IsNullOrWhiteSpace(_runParameters.SettingsFile) == false)
             {
-                var isConfigFileExists = File.Exists(_runParameters.SettingsFile); 
+                bool isConfigFileExists = File.Exists(_runParameters.SettingsFile);
                 if (isConfigFileExists)
                 {
                     OpenConfigFile(_runParameters.SettingsFile);
@@ -112,7 +112,7 @@ namespace SQLQueryStress
 
             if (string.IsNullOrWhiteSpace(_runParameters.DbServer) == false)
             {
-                _settings.MainDbConnectionInfo.Server = _runParameters.DbServer; 
+                _settings.MainDbConnectionInfo.Server = _runParameters.DbServer;
             }
         }
 
@@ -122,11 +122,11 @@ namespace SQLQueryStress
 
             saveSettingsFileDialog.DefaultExt = "json";
             saveSettingsFileDialog.Filter = @"SQLQueryStress Configuration Files|*.json";
-            saveSettingsFileDialog.FileOk += saveSettingsFileDialog_FileOk;
+            saveSettingsFileDialog.FileOk += SaveSettingsFileDialog_FileOk;
 
             loadSettingsFileDialog.DefaultExt = "json";
             loadSettingsFileDialog.Filter = @"SQLQueryStress Configuration Files|*.json";
-            loadSettingsFileDialog.FileOk += loadSettingsFileDialog_FileOk;
+            loadSettingsFileDialog.FileOk += LoadSettingsFileDialog_FileOk;
         }
 
         private void StartProcessing(Object sender, EventArgs e)
@@ -134,21 +134,20 @@ namespace SQLQueryStress
             go_button.PerformClick();
         }
 
-        private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
+        private void AboutToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var a = new AboutBox();
+            AboutBox a = new AboutBox();
             a.ShowDialog();
         }
 
-        private void backgroundWorker1_DoWork(object sender, DoWorkEventArgs e)
+        private void BackgroundWorker1_DoWork(object sender, DoWorkEventArgs e)
         {
-            int tmp;
-            ((LoadEngine) e.Argument).StartLoad(backgroundWorker1, (Int32.TryParse(queryDelay_textBox.Text, out tmp) ? tmp : 0));
+            ((LoadEngine)e.Argument).StartLoad(backgroundWorker1, int.TryParse(queryDelay_textBox.Text, out int tmp) ? tmp : 0);
         }
 
-        private void backgroundWorker1_ProgressChanged(object sender, ProgressChangedEventArgs e)
+        private void BackgroundWorker1_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
-            var output = (LoadEngine.QueryOutput) e.UserState;
+            LoadEngine.QueryOutput output = (LoadEngine.QueryOutput)e.UserState;
 
             _totalIterations++;
 
@@ -176,7 +175,7 @@ namespace SQLQueryStress
                 //of the exception
                 if (_settings.CollectTimeStats)
                 {
-                    var matchPos = output.E.Message.IndexOf("SQL Server parse and compile time:", StringComparison.Ordinal);
+                    int matchPos = output.E.Message.IndexOf("SQL Server parse and compile time:", StringComparison.Ordinal);
 
                     theMessage = matchPos > -1 ? output.E.Message.Substring(0, matchPos - 2) : output.E.Message;
                 }
@@ -204,7 +203,7 @@ namespace SQLQueryStress
             }
         }
 
-        private void backgroundWorker1_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
+        private void BackgroundWorker1_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             mainUITimer.Stop();
 
@@ -219,13 +218,13 @@ namespace SQLQueryStress
             if (!_cancelled)
                 progressBar1.Value = 100;
 
-            ((BackgroundWorker) sender).Dispose();
+            ((BackgroundWorker)sender).Dispose();
 
             db_label.Text = "";
 
             if (string.IsNullOrEmpty(_runParameters.ResultsAutoSaveFileName) == false)
             {
-                AutoSaveResults(_runParameters.ResultsAutoSaveFileName); 
+                AutoSaveResults(_runParameters.ResultsAutoSaveFileName);
             }
 
             // if we started automatically exit when done
@@ -248,7 +247,7 @@ namespace SQLQueryStress
             }
         }
 
-        private void cancel_button_Click(object sender, EventArgs e)
+        private void Cancel_button_Click(object sender, EventArgs e)
         {
             cancel_button.Enabled = false;
 
@@ -262,23 +261,23 @@ namespace SQLQueryStress
             }
         }
 
-        private void database_button_Click(object sender, EventArgs e)
+        private void Database_button_Click(object sender, EventArgs e)
         {
-            var dbselect = new DatabaseSelect(_settings) {StartPosition = FormStartPosition.CenterParent};
+            DatabaseSelect dbselect = new DatabaseSelect(_settings) { StartPosition = FormStartPosition.CenterParent };
             dbselect.ShowDialog();
         }
 
-        private void exceptions_button_Click(object sender, EventArgs e)
+        private void Exceptions_button_Click(object sender, EventArgs e)
         {
-            totalExceptions_textBox_Click(null, null);
+            TotalExceptions_textBox_Click(null, null);
         }
 
-        private void exitToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ExitToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Dispose();
         }
 
-        private void go_button_Click(object sender, EventArgs e)
+        private void Go_button_Click(object sender, EventArgs e)
         {
             if (!_settings.MainDbConnectionInfo.TestConnection())
             {
@@ -319,11 +318,11 @@ namespace SQLQueryStress
 
             _totalExpectedIterations = _settings.NumThreads * _settings.NumIterations;
 
-            var paramConnectionInfo = _settings.ShareDbSettings ? _settings.MainDbConnectionInfo : _settings.ParamDbConnectionInfo;
+            ConnectionInfo paramConnectionInfo = _settings.ShareDbSettings ? _settings.MainDbConnectionInfo : _settings.ParamDbConnectionInfo;
             db_label.Text = "" + @"Server: " + paramConnectionInfo.Server +
                             (paramConnectionInfo.Database.Length > 0 ? "  //  Database: " + paramConnectionInfo.Database : "");
 
-            var engine = new LoadEngine(_settings.MainDbConnectionInfo.ConnectionString, _settings.MainQuery, _settings.NumThreads, _settings.NumIterations,
+            LoadEngine engine = new LoadEngine(_settings.MainDbConnectionInfo.ConnectionString, _settings.MainQuery, _settings.NumThreads, _settings.NumIterations,
                 _settings.ParamQuery, _settings.ParamMappings, paramConnectionInfo.ConnectionString, _settings.CommandTimeout, _settings.CollectIoStats,
                 _settings.CollectTimeStats, _settings.ForceDataRetrieval, _settings.KillQueriesOnCancel);
 
@@ -334,12 +333,12 @@ namespace SQLQueryStress
             mainUITimer.Start();
         }
 
-        private void loadSettingsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void LoadSettingsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             loadSettingsFileDialog.ShowDialog();
         }
 
-        private void mainUITimer_Tick(object sender, EventArgs e)
+        private void MainUITimer_Tick(object sender, EventArgs e)
         {
             UpdateUi();
         }
@@ -348,7 +347,7 @@ namespace SQLQueryStress
         {
             try
             {
-                var contents = File.ReadAllText(fileName);
+                string contents = File.ReadAllText(fileName);
                 _settings = JsonSerializer.ReadToObject<QueryStressSettings>(contents);
             }
             catch (Exception exc)
@@ -356,8 +355,7 @@ namespace SQLQueryStress
                 MessageBox.Show(string.Format("{0}: {1}", Resources.ErrLoadingSettings, exc.Message));
             }
 
-            var sqlControl = elementHost1.Child as SqlControl;
-            if (sqlControl != null)
+            if (elementHost1.Child is SqlControl sqlControl)
             {
                 sqlControl.Text = _settings.MainQuery;
             }
@@ -366,71 +364,69 @@ namespace SQLQueryStress
             queryDelay_textBox.Text = _settings.DelayBetweenQueries.ToString();
         }
 
-        private void loadSettingsFileDialog_FileOk(object sender, EventArgs e)
+        private void LoadSettingsFileDialog_FileOk(object sender, EventArgs e)
         {
             OpenConfigFile(loadSettingsFileDialog.FileName);
         }
 
-        private void optionsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void OptionsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var options = new Options(_settings);
+            Options options = new Options(_settings);
             options.ShowDialog();
         }
 
-        private void param_button_Click(object sender, EventArgs e)
+        private void Param_button_Click(object sender, EventArgs e)
         {
-            var sqlControl = elementHost1.Child as SqlControl;
-            if (sqlControl != null)
+            if (elementHost1.Child is SqlControl sqlControl)
             {
-                var p = new ParamWindow(_settings, sqlControl.Text) {StartPosition = FormStartPosition.CenterParent};
+                ParamWindow p = new ParamWindow(_settings, sqlControl.Text) { StartPosition = FormStartPosition.CenterParent };
                 p.ShowDialog();
             }
         }
 
-        private void saveSettingsFileDialog_FileOk(object sender, EventArgs e)
+        private void SaveSettingsFileDialog_FileOk(object sender, EventArgs e)
         {
             try
             {
-                var jsonContent = JsonSerializer.WriteFromObject(_settings);
+                string jsonContent = JsonSerializer.WriteFromObject(_settings);
                 File.WriteAllText(saveSettingsFileDialog.FileName, jsonContent);
             }
             catch (Exception exc)
             {
-                MessageBox.Show(string.Format("{0}: {1}", Resources.ErrorSavingSettings, exc.Message)); 
+                MessageBox.Show(string.Format("{0}: {1}", Resources.ErrorSavingSettings, exc.Message));
             }
         }
 
         private void SaveSettingsFromForm1()
         {
-            var sqlControl = elementHost1.Child as SqlControl;
-            if (sqlControl != null) _settings.MainQuery =  sqlControl.Text;
-            _settings.NumThreads = (int) threads_numericUpDown.Value;
-            _settings.NumIterations = (int) iterations_numericUpDown.Value;
+            if (elementHost1.Child is SqlControl sqlControl) _settings.MainQuery = sqlControl.Text;
+            _settings.NumThreads = (int)threads_numericUpDown.Value;
+            _settings.NumIterations = (int)iterations_numericUpDown.Value;
             _settings.DelayBetweenQueries = int.Parse(queryDelay_textBox.Text);
         }
 
-        private void saveSettingsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void SaveSettingsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SaveSettingsFromForm1();
             saveSettingsFileDialog.ShowDialog();
         }
 
-        private void totalExceptions_textBox_Click(object sender, EventArgs e)
+        private void TotalExceptions_textBox_Click(object sender, EventArgs e)
         {
-            _exceptionViewer = new DataViewer {StartPosition = FormStartPosition.CenterParent, Text = Resources.Exceptions};
+            _exceptionViewer = new DataViewer { StartPosition = FormStartPosition.CenterParent, Text = Resources.Exceptions };
 
-            var dt = new DataTable();
+            DataTable dt = new DataTable();
             dt.Columns.Add("Count");
             dt.Columns.Add("Exception");
 
             if (_exceptions != null)
             {
-                var values = _exceptions.Values.GetEnumerator();
+                Dictionary<string, int>.ValueCollection.Enumerator values = _exceptions.Values.GetEnumerator();
 
-                foreach (var ex in _exceptions.Keys)
+                foreach (string ex in _exceptions.Keys)
                 {
                     values.MoveNext();
-                    var count = values.Current;
+                    int count = values.Current;
                     dt.Rows.Add(count, ex);
                 }
             }
@@ -443,10 +439,10 @@ namespace SQLQueryStress
         private void UpdateUi()
         {
             iterationsSecond_textBox.Text = _totalIterations.ToString();
-            var avgIterations = _totalIterations == 0 ? 0.0 : _totalTime / _totalIterations / 1000;
-            var avgCpu = _totalTimeMessages == 0 ? 0.0 : _totalCpuTime / _totalTimeMessages / 1000;
-            var avgActual = _totalTimeMessages == 0 ? 0.0 : _totalElapsedTime / _totalTimeMessages / 1000;
-            var avgReads = _totalReadMessages == 0 ? 0.0 : _totalLogicalReads / _totalReadMessages;
+            double avgIterations = _totalIterations == 0 ? 0.0 : _totalTime / _totalIterations / 1000;
+            double avgCpu = _totalTimeMessages == 0 ? 0.0 : _totalCpuTime / _totalTimeMessages / 1000;
+            double avgActual = _totalTimeMessages == 0 ? 0.0 : _totalElapsedTime / _totalTimeMessages / 1000;
+            double avgReads = _totalReadMessages == 0 ? 0.0 : _totalLogicalReads / _totalReadMessages;
 
             avgSeconds_textBox.Text = avgIterations.ToString("0.0000");
             cpuTime_textBox.Text = _totalTimeMessages == 0 ? "---" : avgCpu.ToString("0.0000");
@@ -454,12 +450,12 @@ namespace SQLQueryStress
             logicalReads_textBox.Text = _totalReadMessages == 0 ? "---" : avgReads.ToString("0.0000");
 
             totalExceptions_textBox.Text = _totalExceptions.ToString();
-            progressBar1.Value = Math.Min((int) (_totalIterations / (decimal) _totalExpectedIterations * 100), 100);
+            progressBar1.Value = Math.Min((int)(_totalIterations / (decimal)_totalExpectedIterations * 100), 100);
 
-            var end = new TimeSpan(DateTime.Now.Ticks);
+            TimeSpan end = new TimeSpan(DateTime.Now.Ticks);
             end = end.Subtract(_start);
 
-            var theTime = end.ToString();
+            string theTime = end.ToString();
 
             //Some systems return "hh:mm:ss" instead of "hh:mm:ss.0000" if
             //there is no fractional part of the second.  I'm not sure
@@ -470,14 +466,14 @@ namespace SQLQueryStress
                 elapsedTime_textBox.Text = theTime + @".0000";
         }
 
-        private void btnCleanBuffer_Click(object sender, EventArgs e)
+        private void BtnCleanBuffer_Click(object sender, EventArgs e)
         {
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC DROPCLEANBUFFERS")
                 ? "Buffers cleared"
                 : "Errors encountered");
         }
 
-        private void btnFreeCache_Click(object sender, EventArgs e)
+        private void BtnFreeCache_Click(object sender, EventArgs e)
         {
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC FREEPROCCACHE")
                 ? "Cache freed"
@@ -485,12 +481,14 @@ namespace SQLQueryStress
         }
 
 
-        private void toTextToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ToTextToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var saveFileDialog = new SaveFileDialog();
-            saveFileDialog.AddExtension = true;
-            saveFileDialog.OverwritePrompt = false;
-            saveFileDialog.Filter = "Text Files (*.txt)|*.txt";
+            SaveFileDialog saveFileDialog = new SaveFileDialog
+            {
+                AddExtension = true,
+                OverwritePrompt = false,
+                Filter = "Text Files (*.txt)|*.txt"
+            };
             saveFileDialog.ShowDialog();
 
             if (!string.IsNullOrEmpty(saveFileDialog.FileName))
@@ -501,7 +499,7 @@ namespace SQLQueryStress
         {
             try
             {
-                var textWriter = new StreamWriter(fileName, true);
+                StreamWriter textWriter = new StreamWriter(fileName, true);
                 WriteBenchmarkTextContent(textWriter);
                 textWriter.Close();
             }
@@ -509,7 +507,7 @@ namespace SQLQueryStress
             {
                 MessageBox
                     .Show("Error While Saving BenchMark",
-                    string.Format("There was an error saving the benchmark to '{0}', make sure you have write privileges to that path",fileName));
+                    string.Format("There was an error saving the benchmark to '{0}', make sure you have write privileges to that path", fileName));
             }
         }
 
@@ -541,11 +539,11 @@ namespace SQLQueryStress
         }
 
 
-        private void toClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
         {
             try
             {
-                var textWriter = new StringWriter();
+                StringWriter textWriter = new StringWriter();
                 WriteBenchmarkTextContent(textWriter);
                 Clipboard.SetText(textWriter.ToString());
             }
@@ -557,12 +555,14 @@ namespace SQLQueryStress
             }
         }
 
-        private void toCsvToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ToCsvToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var saveFileDialog = new SaveFileDialog();
-            saveFileDialog.AddExtension = true;
-            saveFileDialog.OverwritePrompt = false;
-            saveFileDialog.Filter = "Csv Files (*.csv)|*.csv";
+            SaveFileDialog saveFileDialog = new SaveFileDialog
+            {
+                AddExtension = true,
+                OverwritePrompt = false,
+                Filter = "Csv Files (*.csv)|*.csv"
+            };
             saveFileDialog.ShowDialog();
 
             if (!string.IsNullOrEmpty(saveFileDialog.FileName))
@@ -573,8 +573,8 @@ namespace SQLQueryStress
         {
             try
             {
-                var fileExists = File.Exists(fileName);
-                var textWriter = new StreamWriter(fileName, true);
+                bool fileExists = File.Exists(fileName);
+                StreamWriter textWriter = new StreamWriter(fileName, true);
                 // we do not write the header line if we are appending to an existing file 
                 if (fileExists == false)
                 {

--- a/src/SQLQueryStress/JsonSerializer.cs
+++ b/src/SQLQueryStress/JsonSerializer.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace SQLQueryStress
 {
@@ -30,8 +26,5 @@ namespace SQLQueryStress
                 return Encoding.UTF8.GetString(json, 0, json.Length);
             }
         }
-
-
-
     }
 }

--- a/src/SQLQueryStress/JsonSerializer.cs
+++ b/src/SQLQueryStress/JsonSerializer.cs
@@ -12,9 +12,9 @@ namespace SQLQueryStress
     {
         public static T ReadToObject<T>(string json)
         {
-            using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            using (MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
             {
-                var serializer = new DataContractJsonSerializer(typeof(T));
+                DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(T));
                 T retObj = (T)serializer.ReadObject(memoryStream);
                 return retObj;
             }
@@ -22,9 +22,9 @@ namespace SQLQueryStress
 
         public static string WriteFromObject<T>(T user)
         {
-            using (var memoryStream = new MemoryStream())
+            using (MemoryStream memoryStream = new MemoryStream())
             {
-                var serializer = new DataContractJsonSerializer(typeof(T));
+                DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(T));
                 serializer.WriteObject(memoryStream, user);
                 byte[] json = memoryStream.ToArray();
                 return Encoding.UTF8.GetString(json, 0, json.Length);

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -148,6 +148,7 @@ namespace SQLQueryStress
                     _iterations, _forceDataRetrieval, _queryDelay, worker, _killQueriesOnCancel);
 
                 Thread theThread = new Thread(input.StartLoadThread) { Priority = ThreadPriority.BelowNormal };
+                input.Dispose();
 
                 _threadPool.Add(theThread);
                 _commandPool.Add(queryComm);
@@ -262,7 +263,6 @@ namespace SQLQueryStress
             //queryOutInfo.Clear();
         }
 
-
         //TODO: Monostate pattern to be investigated (class is never instantiated)
         private class ParamServer
         {
@@ -304,6 +304,7 @@ namespace SQLQueryStress
                 SqlDataAdapter a = new SqlDataAdapter(paramQuery, connString);
                 _theParams = new DataTable();
                 a.Fill(_theParams);
+                a.Dispose();
 
                 _numRows = _theParams.Rows.Count;
 

--- a/src/SQLQueryStress/Options.Designer.cs
+++ b/src/SQLQueryStress/Options.Designer.cs
@@ -120,7 +120,7 @@ namespace SQLQueryStress
             this.ok_button.TabIndex = 2;
             this.ok_button.Text = "OK";
             this.ok_button.UseVisualStyleBackColor = true;
-            this.ok_button.Click += new System.EventHandler(this.ok_button_Click);
+            this.ok_button.Click += new System.EventHandler(this.Ok_button_Click);
             // 
             // cancel_button
             // 
@@ -132,7 +132,7 @@ namespace SQLQueryStress
             this.cancel_button.TabIndex = 3;
             this.cancel_button.Text = "Cancel";
             this.cancel_button.UseVisualStyleBackColor = true;
-            this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
+            this.cancel_button.Click += new System.EventHandler(this.Cancel_button_Click);
             // 
             // groupBox1
             // 

--- a/src/SQLQueryStress/Options.cs
+++ b/src/SQLQueryStress/Options.cs
@@ -33,8 +33,8 @@ namespace SQLQueryStress
 
         private void ok_button_Click(object sender, EventArgs e)
         {
-            _settings.ConnectionTimeout = (int) connectionTimeout_numericUpDown.Value;
-            _settings.CommandTimeout = (int) commandTimeout_numericUpDown.Value;
+            _settings.ConnectionTimeout = (int)connectionTimeout_numericUpDown.Value;
+            _settings.CommandTimeout = (int)commandTimeout_numericUpDown.Value;
             _settings.EnableConnectionPooling = connectionPooling_checkBox.Checked;
             _settings.CollectIoStats = IOStatistics_checkBox.Checked;
             _settings.CollectTimeStats = timeStatistics_checkBox.Checked;

--- a/src/SQLQueryStress/Options.cs
+++ b/src/SQLQueryStress/Options.cs
@@ -26,12 +26,12 @@ namespace SQLQueryStress
             killQueriesOnCancel_checkBox.Checked = settings.KillQueriesOnCancel;
         }
 
-        private void cancel_button_Click(object sender, EventArgs e)
+        private void Cancel_button_Click(object sender, EventArgs e)
         {
             Dispose();
         }
 
-        private void ok_button_Click(object sender, EventArgs e)
+        private void Ok_button_Click(object sender, EventArgs e)
         {
             _settings.ConnectionTimeout = (int)connectionTimeout_numericUpDown.Value;
             _settings.CommandTimeout = (int)commandTimeout_numericUpDown.Value;

--- a/src/SQLQueryStress/ParamWindow.Designer.cs
+++ b/src/SQLQueryStress/ParamWindow.Designer.cs
@@ -98,7 +98,7 @@ namespace SQLQueryStress
             this.getColumnsButton.TabIndex = 1;
             this.getColumnsButton.Text = "Get Columns";
             this.getColumnsButton.UseVisualStyleBackColor = true;
-            this.getColumnsButton.Click += new System.EventHandler(this.getColumnsButton_Click);
+            this.getColumnsButton.Click += new System.EventHandler(this.GetColumnsButton_Click);
             // 
             // okButton
             // 
@@ -110,7 +110,7 @@ namespace SQLQueryStress
             this.okButton.TabIndex = 4;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            this.okButton.Click += new System.EventHandler(this.OkButton_Click);
             // 
             // cancelButton
             // 
@@ -123,7 +123,7 @@ namespace SQLQueryStress
             this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
             // label2
             // 
@@ -146,7 +146,7 @@ namespace SQLQueryStress
             this.database_button.TabIndex = 2;
             this.database_button.Text = "Database";
             this.database_button.UseVisualStyleBackColor = true;
-            this.database_button.Click += new System.EventHandler(this.database_button_Click);
+            this.database_button.Click += new System.EventHandler(this.Database_button_Click);
             // 
             // elementHost1
             // 

--- a/src/SQLQueryStress/ParamWindow.cs
+++ b/src/SQLQueryStress/ParamWindow.cs
@@ -82,6 +82,7 @@ namespace SQLQueryStress
         {
             DatabaseSelect dbSelect = new DatabaseSelect(_settings) { StartPosition = FormStartPosition.CenterParent };
             dbSelect.ShowDialog();
+            dbSelect.Dispose();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities")]
@@ -108,6 +109,7 @@ namespace SQLQueryStress
                         SqlCommand comm = new SqlCommand(sqlControl.Text, conn);
                         conn.Open();
                         reader = comm.ExecuteReader(CommandBehavior.SchemaOnly);
+                        comm.Dispose();
                     }
                 }
                 catch (Exception ex)

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -19,19 +19,18 @@ namespace SQLQueryStress
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-
-            var options = new CommandLineOptions();
+            CommandLineOptions options = new CommandLineOptions();
             ICommandLineParser parser = new CommandLineParser();
-            var writer = new StringWriter();
+            StringWriter writer = new StringWriter();
             parser.ParseArguments(args, options, writer);
-            
+
             if (writer.GetStringBuilder().Length > 0)
             {
                 MessageBox.Show(writer.GetStringBuilder().ToString());
             }
             else
             {
-                var f = new Form1(options)
+                Form1 f = new Form1(options)
                 {
                     StartPosition = FormStartPosition.CenterScreen
                 };
@@ -41,17 +40,17 @@ namespace SQLQueryStress
 
         private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)
         {
-            var dllName = new AssemblyName(args.Name).Name + ".dll";
-            var assem = Assembly.GetExecutingAssembly();
-            var resourceName = assem.GetManifestResourceNames().FirstOrDefault(rn => rn.EndsWith(dllName));
+            string dllName = new AssemblyName(args.Name).Name + ".dll";
+            Assembly assem = Assembly.GetExecutingAssembly();
+            string resourceName = assem.GetManifestResourceNames().FirstOrDefault(rn => rn.EndsWith(dllName));
             if (resourceName == null) return null; // Not found, maybe another handler will find it
-            using (var stream = assem.GetManifestResourceStream(resourceName))
+            using (Stream stream = assem.GetManifestResourceStream(resourceName))
             {
                 if (stream == null)
                 {
                     return null;
                 }
-                var assemblyData = new byte[stream.Length];
+                byte[] assemblyData = new byte[stream.Length];
                 stream.Read(assemblyData, 0, assemblyData.Length);
                 return Assembly.Load(assemblyData);
             }

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -1,9 +1,9 @@
+using CommandLine;
 using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using CommandLine;
 
 namespace SQLQueryStress
 {
@@ -22,6 +22,7 @@ namespace SQLQueryStress
             CommandLineOptions options = new CommandLineOptions();
             ICommandLineParser parser = new CommandLineParser();
             StringWriter writer = new StringWriter();
+
             parser.ParseArguments(args, options, writer);
 
             if (writer.GetStringBuilder().Length > 0)
@@ -35,7 +36,10 @@ namespace SQLQueryStress
                     StartPosition = FormStartPosition.CenterScreen
                 };
                 Application.Run(f);
+                f.Dispose();
             }
+
+            writer.Dispose();
         }
 
         private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)
@@ -43,7 +47,9 @@ namespace SQLQueryStress
             string dllName = new AssemblyName(args.Name).Name + ".dll";
             Assembly assem = Assembly.GetExecutingAssembly();
             string resourceName = assem.GetManifestResourceNames().FirstOrDefault(rn => rn.EndsWith(dllName));
+
             if (resourceName == null) return null; // Not found, maybe another handler will find it
+            
             using (Stream stream = assem.GetManifestResourceStream(resourceName))
             {
                 if (stream == null)

--- a/src/SQLQueryStress/Properties/AssemblyInfo.cs
+++ b/src/SQLQueryStress/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿#region
+﻿using System.Resources;
+#region
 
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -38,3 +39,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("0.9.7.0")]
 [assembly: AssemblyFileVersion("0.9.7.0")]
+[assembly: NeutralResourcesLanguage("en")]

--- a/src/SQLQueryStress/QueryStressSettings.cs
+++ b/src/SQLQueryStress/QueryStressSettings.cs
@@ -1,12 +1,9 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-
 namespace SQLQueryStress
 {
-
     [Serializable]
     [DataContract]
     public class QueryStressSettings

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -42,6 +47,8 @@
     <ApplicationVersion>0.9.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,7 +60,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -197,6 +204,7 @@
     </Compile>
     <None Include="App.config" />
     <BaseApplicationManifest Include="Properties\app.manifest" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -236,7 +244,28 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\analyzers\dotnet\cs\Microsoft.CodeAnalysis.VersionCheckAnalyzer.resources.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -1,10 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
-  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -31,6 +26,8 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>2.0</OldToolsVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <PublishUrl>c:\testdeploy\querystress\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -47,8 +44,6 @@
     <ApplicationVersion>0.9.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,6 +68,7 @@
     <CodeAnalysisRules>
     </CodeAnalysisRules>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>SQLQueryStress.Program</StartupObject>
@@ -207,7 +203,6 @@
     </Compile>
     <None Include="App.config" />
     <BaseApplicationManifest Include="Properties\app.manifest" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -247,28 +242,7 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\analyzers\dotnet\cs\Microsoft.CodeAnalysis.VersionCheckAnalyzer.resources.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Humanizer.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.8\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.8\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.8\build\Microsoft.CodeQuality.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.8\build\Microsoft.NetCore.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.8\build\Microsoft.NetFramework.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -74,6 +74,9 @@
     </CodeAnalysisRules>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>SQLQueryStress.Program</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.1.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/SQLQueryStress/SqlControl.xaml.cs
+++ b/src/SQLQueryStress/SqlControl.xaml.cs
@@ -27,8 +27,10 @@ namespace SQLQueryStress
                 stream =
                     System.Reflection.Assembly.GetExecutingAssembly()
                         .GetManifestResourceStream("SQLQueryStress.Resources.SQL.xshd");
+
                 if (stream == null) return;
-                using (var reader = new System.Xml.XmlTextReader(stream))
+
+                using (System.Xml.XmlTextReader reader = new System.Xml.XmlTextReader(stream))
                 {
                     stream = null;
                     AvalonEdit.SyntaxHighlighting =
@@ -39,7 +41,7 @@ namespace SQLQueryStress
             finally
             {
                 if (stream != null)
-                    stream.Dispose();    
+                    stream.Dispose();
             }
         }
     }

--- a/src/SQLQueryStress/packages.config
+++ b/src/SQLQueryStress/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.NetCore.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.NetFramework.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
+</packages>

--- a/src/SQLQueryStress/packages.config
+++ b/src/SQLQueryStress/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.NetCore.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.NetFramework.Analyzers" version="2.9.8" targetFramework="net461" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
Hi Erik!
I noticed a bug where the app would crash if I clicked on the Clean Buffers or Free Cache buttons while not connected to the database.
Also thought I'd try out turning on Microsoft's Visual Studio warnings to see what cropped up,, hence all the small edits to remove redundant "this" keywords, to add Dispose() calls where needed, and to capitalise the first letter of some function names.
I also added a framerate limiter to the UI Update function, since when testing with many threads, there might be loads finishing within each second, which clogs the CPU and stops the app UI from refreshing anyway.

The solution still builds fine and I did some testing of it by running some Stress scripts on a local database.

Let me know what you think!

Thanks,
Orestes