### PR TITLE
Reworked the code to use BlockingCollection to manage the queue. Puls…

### DIFF
--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -1,9 +1,9 @@
+using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading;


### PR DESCRIPTION
Changed to use BlockingCollection to manage the synchronization. Pulse and Wait isn't recommended because if a pulse happens when there's nothing waiting, the next wait will wait forever (or until the next pulse). Easier to let BlockingCollection handle the details. In taking Brent Ozar's training, he was constantly talking about this bug of how cancel fails and he has to kill the process in the task manager. I didn't see an issue for this and I don't know the reproduction steps, but I believe it's related to the important note in this article https://docs.microsoft.com/en-us/dotnet/api/system.threading.monitor.pulse?view=netcore-3.1.