### PR TITLE
CommandLine bug fixes

### DIFF
--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -598,7 +598,7 @@ namespace SQLQueryStress
 
         private static void WriteBenchmarkCsvHeader(StreamWriter tw)
         {
-            tw.WriteLine("TestId,TestStartTime,ElapsedTime,Iterations,Threads,Delay,CompletedIterations,AvgCPUSeconds,AvgActualSeconds,AvgClientSeconds,AvgLogicalReads");
+            tw.WriteLine("TestId,TestStartTime,ElapsedTime,Iterations,Threads,Delay,CompletedIterations,AvgCPUSeconds,AvgActualSeconds,AvgClientSeconds,AvgLogicalReads,HostMachine");
         }
 
         private void WriteBenchmarkCsvText(TextWriter tw)

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -86,7 +86,7 @@ namespace SQLQueryStress
 
         private System.Threading.CancellationTokenSource _backgroundWorkerCTS;
 
-        private SqlControl sqlControl1;
+        private SqlControl sqlControl1 = new SqlControl();
 
         public Form1(CommandLineOptions runParameters) : this()
         {
@@ -367,7 +367,7 @@ namespace SQLQueryStress
             {
                 MessageBox.Show($"{Resources.ErrLoadingSettings}: {ex.Message}");
             }
-            sqlControl1 = new SqlControl();
+            //sqlControl1 = new SqlControl();
             sqlControl1.Text = _settings.MainQuery;
             
             threads_numericUpDown.Value = _settings.NumThreads;
@@ -621,7 +621,7 @@ namespace SQLQueryStress
         private void Form1_Load(object sender, EventArgs e)
         {
             var elemHost = new System.Windows.Forms.Integration.ElementHost();
-            sqlControl1 = new SqlControl();
+            //sqlControl1 = new SqlControl();
             elemHost.Dock = DockStyle.Fill;
             elemHost.Location = new System.Drawing.Point(4, 5);
             elemHost.Margin = new Padding(4, 5, 4, 5);

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -532,6 +532,7 @@ namespace SQLQueryStress
         private void WriteBenchmarkTextContent(TextWriter tw)
         {
             tw.WriteLine($"Test ID: {_testGuid}");
+            tw.WriteLine($"Host Machine : {Environment.MachineName.ToString()}");
             tw.WriteLine($"Test TimeStamp: {_testStartTime}");
             tw.WriteLine($"Elapsed Time: {elapsedTime_textBox.Text}");
             tw.WriteLine($"Number of Iterations: {(int)iterations_numericUpDown.Value}");
@@ -602,7 +603,7 @@ namespace SQLQueryStress
 
         private void WriteBenchmarkCsvText(TextWriter tw)
         {
-            tw.WriteLine("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}",
+            tw.WriteLine("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}",
                 _testGuid,
                 _testStartTime,
                 elapsedTime_textBox.Text,
@@ -613,7 +614,8 @@ namespace SQLQueryStress
                 cpuTime_textBox.Text,
                 actualSeconds_textBox.Text,
                 avgSeconds_textBox.Text,
-                logicalReads_textBox.Text
+                logicalReads_textBox.Text,
+                Environment.MachineName.ToString()
                 );
         }
 

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -367,7 +367,6 @@ namespace SQLQueryStress
             {
                 MessageBox.Show($"{Resources.ErrLoadingSettings}: {ex.Message}");
             }
-            //sqlControl1 = new SqlControl();
             sqlControl1.Text = _settings.MainQuery;
             
             threads_numericUpDown.Value = _settings.NumThreads;
@@ -621,7 +620,6 @@ namespace SQLQueryStress
         private void Form1_Load(object sender, EventArgs e)
         {
             var elemHost = new System.Windows.Forms.Integration.ElementHost();
-            //sqlControl1 = new SqlControl();
             elemHost.Dock = DockStyle.Fill;
             elemHost.Location = new System.Drawing.Point(4, 5);
             elemHost.Margin = new Padding(4, 5, 4, 5);

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -367,7 +367,7 @@ namespace SQLQueryStress
             {
                 MessageBox.Show($"{Resources.ErrLoadingSettings}: {ex.Message}");
             }
-
+            sqlControl1 = new SqlControl();
             sqlControl1.Text = _settings.MainQuery;
             
             threads_numericUpDown.Value = _settings.NumThreads;

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -54,6 +54,7 @@ namespace SQLQueryStress
                     help.AddPreOptionsLine("Check for updates at: https://github.com/ErikEJ/SqlQueryStress");
                     help.AddPreOptionsLine("Sample usage:");
                     help.AddPreOptionsLine("SqlQueryStress -c saved.SqlStress -u -t 32 -d sqldb.perfenv.mycompany.com -r results.csv");
+                    help.AddPreOptionsLine("SqlQueryStress -c \"c:\\users\\user\\settings.json\" -r \"c:\\users\\user\\stressresults.txt\"");
                     return HelpText.DefaultParsingErrorsHandler(result, help);
                 }, e => e);
 


### PR DESCRIPTION
Form1.cs : Fixed an issue that ends up in the below error when used from CommandLine. Exception Info: System.NullReferenceException: Object reference not set to an instance of an object. 
Program.cs : Added another usage of the commandline. I think file names without file path isnt working. I will have to debug more to understand why File.Exists doesnt work in OpenConfigFile method