### PR TITLE
Don't force garbage collection in a tight loop

### DIFF
--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -194,7 +194,6 @@ namespace SQLQueryStress
                     theOut.ActiveThreads = _threads - finishedThreads;
                     worker.ReportProgress((int)(_finishedThreads / (decimal)_threads * 100), theOut);
                 }
-                GC.Collect();
             }
         }
 


### PR DESCRIPTION
While testing very simple queries like SELECT 1, I noticed that I cannot go above 100 batch requests per second.
Profiling pointed me to forced garbage collection. Removing this single line allowed me to increase the speed to 40k requests/s. Quite nice improvement.