### PR TITLE
Small UI improvements

### DIFF
--- a/src/SQLQueryStress/Form1.Designer.cs
+++ b/src/SQLQueryStress/Form1.Designer.cs
@@ -102,7 +102,7 @@ namespace SQLQueryStress
             this.btnFreeCache = new System.Windows.Forms.Button();
             this.btnCleanBuffer = new System.Windows.Forms.Button();
             this.label11 = new System.Windows.Forms.Label();
-            this.queryDelay_textBox = new System.Windows.Forms.TextBox();
+            this.queryDelay_numericUpDown = new System.Windows.Forms.NumericUpDown();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.iterations_numericUpDown)).BeginInit();
@@ -111,6 +111,7 @@ namespace SQLQueryStress
             this.flowLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.queryDelay_numericUpDown)).BeginInit();
             this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -606,7 +607,7 @@ namespace SQLQueryStress
             this.tableLayoutPanel1.Controls.Add(this.param_button, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.queryDelay_textBox, 0, 10);
+            this.tableLayoutPanel1.Controls.Add(this.queryDelay_numericUpDown, 0, 10);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(391, 4);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -746,15 +747,19 @@ namespace SQLQueryStress
             this.label11.TabIndex = 34;
             this.label11.Text = "Delay between queries (ms)";
             // 
-            // queryDelay_textBox
+            // queryDelay_numericUpDown
             // 
-            this.queryDelay_textBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.queryDelay_textBox.Location = new System.Drawing.Point(3, 308);
-            this.queryDelay_textBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.queryDelay_textBox.Name = "queryDelay_textBox";
-            this.queryDelay_textBox.Size = new System.Drawing.Size(230, 23);
-            this.queryDelay_textBox.TabIndex = 5;
-            this.queryDelay_textBox.Text = "0";
+            this.queryDelay_numericUpDown.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.queryDelay_numericUpDown.Location = new System.Drawing.Point(3, 308);
+            this.queryDelay_numericUpDown.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.queryDelay_numericUpDown.Maximum = new decimal(new int[] {
+            1000000,
+            0,
+            0,
+            0});
+            this.queryDelay_numericUpDown.Name = "queryDelay_numericUpDown";
+            this.queryDelay_numericUpDown.Size = new System.Drawing.Size(230, 23);
+            this.queryDelay_numericUpDown.TabIndex = 5;
             // 
             // tableLayoutPanel3
             // 
@@ -797,6 +802,7 @@ namespace SQLQueryStress
             this.flowLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel4.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.queryDelay_numericUpDown)).EndInit();
             this.tableLayoutPanel3.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -853,7 +859,7 @@ namespace SQLQueryStress
         private Label actualSeconds_textBox;
         private Label label10;
         private Label label11;
-        private TextBox queryDelay_textBox;
+        private NumericUpDown queryDelay_numericUpDown;
         private ToolStripMenuItem saveBenchMarkToolStripMenuItem;
         private ToolStripMenuItem toCsvToolStripMenuItem;
         private ToolStripMenuItem toTextToolStripMenuItem;

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -147,7 +147,7 @@ namespace SQLQueryStress
 
         private void backgroundWorker1_DoWork(object sender, DoWorkEventArgs e)
         {
-            ((LoadEngine)e.Argument).StartLoad(backgroundWorker1, (int.TryParse(queryDelay_textBox.Text, out int tmp) ? tmp : 0));
+            ((LoadEngine)e.Argument).StartLoad(backgroundWorker1, (int.TryParse(queryDelay_numericUpDown.Text, out int tmp) ? tmp : 0));
         }
 
         private void backgroundWorker1_ProgressChanged(object sender, ProgressChangedEventArgs e)
@@ -220,7 +220,7 @@ namespace SQLQueryStress
             cancel_button.Enabled = false;
             threads_numericUpDown.Enabled = true;
             iterations_numericUpDown.Enabled = true;
-            queryDelay_textBox.Enabled = true;
+            queryDelay_numericUpDown.Enabled = true;
 
             if (!_cancelled)
                 progressBar1.Value = 100;
@@ -324,7 +324,7 @@ namespace SQLQueryStress
             cancel_button.Enabled = true;
             iterations_numericUpDown.Enabled = false;
             threads_numericUpDown.Enabled = false;
-            queryDelay_textBox.Enabled = false;
+            queryDelay_numericUpDown.Enabled = false;
 
             progressBar1.Value = 0;
 
@@ -372,7 +372,7 @@ namespace SQLQueryStress
             
             threads_numericUpDown.Value = _settings.NumThreads;
             iterations_numericUpDown.Value = _settings.NumIterations;
-            queryDelay_textBox.Text = _settings.DelayBetweenQueries.ToString(CultureInfo.InvariantCulture);
+            queryDelay_numericUpDown.Text = _settings.DelayBetweenQueries.ToString(CultureInfo.InvariantCulture);
         }
 
         private void loadSettingsFileDialog_FileOk(object sender, EventArgs e)
@@ -410,7 +410,7 @@ namespace SQLQueryStress
             _settings.MainQuery = sqlControl1.Text;
             _settings.NumThreads = (int)threads_numericUpDown.Value;
             _settings.NumIterations = (int)iterations_numericUpDown.Value;
-            _settings.DelayBetweenQueries = int.Parse(queryDelay_textBox.Text, CultureInfo.InvariantCulture);
+            _settings.DelayBetweenQueries = (int)queryDelay_numericUpDown.Value;
         }
 
         private void saveSettingsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -537,7 +537,7 @@ namespace SQLQueryStress
             tw.WriteLine($"Elapsed Time: {elapsedTime_textBox.Text}");
             tw.WriteLine($"Number of Iterations: {(int)iterations_numericUpDown.Value}");
             tw.WriteLine($"Number of Threads: {(int)threads_numericUpDown.Value}");
-            tw.WriteLine($"Delay Between Queries (ms): {int.Parse(queryDelay_textBox.Text, CultureInfo.InvariantCulture)}");
+            tw.WriteLine($"Delay Between Queries (ms): {int.Parse(queryDelay_numericUpDown.Text, CultureInfo.InvariantCulture)}");
             tw.WriteLine($"CPU Seconds/Iteration (Avg): {cpuTime_textBox.Text}");
             tw.WriteLine($"Actual Seconds/Iteration (Avg): {actualSeconds_textBox.Text}");
             tw.WriteLine($"Iterations Completed: {iterationsSecond_textBox.Text}");
@@ -609,7 +609,7 @@ namespace SQLQueryStress
                 elapsedTime_textBox.Text,
                 (int)iterations_numericUpDown.Value,
                 (int)threads_numericUpDown.Value,
-                int.Parse(queryDelay_textBox.Text, CultureInfo.InvariantCulture),
+                int.Parse(queryDelay_numericUpDown.Text, CultureInfo.InvariantCulture),
                 iterationsSecond_textBox.Text,
                 cpuTime_textBox.Text,
                 actualSeconds_textBox.Text,

--- a/src/SQLQueryStress/ParamWindow.Designer.cs
+++ b/src/SQLQueryStress/ParamWindow.Designer.cs
@@ -59,6 +59,7 @@ namespace SQLQueryStress
             this.columnMapGrid.ShowEditingIcon = false;
             this.columnMapGrid.Size = new System.Drawing.Size(438, 185);
             this.columnMapGrid.TabIndex = 3;
+            this.columnMapGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
             // 
             // Column
             // 

--- a/src/SQLQueryStress/ParamWindow.cs
+++ b/src/SQLQueryStress/ParamWindow.cs
@@ -59,7 +59,7 @@ namespace SQLQueryStress
 
         private void columnMapGrid_CellClick(object sender, DataGridViewCellEventArgs e)
         {
-            if (columnMapGrid.CurrentCell.ColumnIndex == 2)
+            if (columnMapGrid.CurrentCell != null && columnMapGrid.CurrentCell.ColumnIndex == 2)
             { 
                 var editingControl = columnMapGrid.EditingControl as
                     DataGridViewComboBoxEditingControl;
@@ -71,7 +71,7 @@ namespace SQLQueryStress
         private void columnMapGrid_CurrentCellDirtyStateChanged(object sender, EventArgs e)
         {
             //handle changes to the parameter column
-            if (columnMapGrid.CurrentCell.ColumnIndex == 2)
+            if (columnMapGrid.CurrentCell != null && columnMapGrid.CurrentCell.ColumnIndex == 2)
             {
                 var theRow = columnMapGrid.Rows[columnMapGrid.CurrentCell.RowIndex];
                 var combo = (DataGridViewComboBoxCell)theRow.Cells[2];

--- a/src/SQLQueryStress/ParamWindow.cs
+++ b/src/SQLQueryStress/ParamWindow.cs
@@ -43,8 +43,8 @@ namespace SQLQueryStress
             columnMapGrid.Columns[1].SortMode = DataGridViewColumnSortMode.NotSortable;
             columnMapGrid.Columns[2].SortMode = DataGridViewColumnSortMode.NotSortable;
 
-            //TODO: Which event to handle?!?!
-            columnMapGrid.CellEndEdit += columnMapGrid_CellValueChanged;
+            columnMapGrid.CurrentCellDirtyStateChanged += columnMapGrid_CurrentCellDirtyStateChanged;
+            columnMapGrid.CellClick += columnMapGrid_CellClick;
 
             if (sqlControl != null && (outerQuery.Length > 0) && (sqlControl.Text.Length > 0))
             {
@@ -57,12 +57,23 @@ namespace SQLQueryStress
             Dispose();
         }
 
-        private void columnMapGrid_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        private void columnMapGrid_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (columnMapGrid.CurrentCell.ColumnIndex == 2)
+            { 
+                var editingControl = columnMapGrid.EditingControl as
+                    DataGridViewComboBoxEditingControl;
+                if (editingControl != null)
+                    editingControl.DroppedDown = true;
+            }
+        }
+
+        private void columnMapGrid_CurrentCellDirtyStateChanged(object sender, EventArgs e)
         {
             //handle changes to the parameter column
-            if (e.ColumnIndex == 2)
+            if (columnMapGrid.CurrentCell.ColumnIndex == 2)
             {
-                var theRow = columnMapGrid.Rows[e.RowIndex];
+                var theRow = columnMapGrid.Rows[columnMapGrid.CurrentCell.RowIndex];
                 var combo = (DataGridViewComboBoxCell)theRow.Cells[2];
 
                 if (combo.Value != null)
@@ -74,6 +85,8 @@ namespace SQLQueryStress
                 {
                     theRow.Cells[1].Value = string.Empty;
                 }
+
+                columnMapGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
             }
         }
 


### PR DESCRIPTION
Changed the parameter mapping grid so it requires only one click anywhere in cell to expand the drop down menu. Previously you needed to click twice on arrow or thrice anywhere in the cell. Also made the datatypes appear instantly when choosing anything from the menu.

Changed the query delay field to numeric. Currently it accepts freefrom text. If a text is entered, it crashes on parsing to int. It also fails when left empty (which happened to me).

I hope my description is clear on what has changed.