### PR TITLE
implement selectable main query text feature

### DIFF
--- a/src/SQLQueryStress/FormMain.cs
+++ b/src/SQLQueryStress/FormMain.cs
@@ -339,6 +339,12 @@ namespace SQLQueryStress
 
             _totalExpectedIterations = _settings.NumThreads * _settings.NumIterations;
 
+            // override main query string with selected text when selected text exists
+            if (sqlControl1.SelectedText.Length != 0)
+            {
+                _settings.MainQuery = sqlControl1.SelectedText;
+            }
+
             var paramConnectionInfo = _settings.ShareDbSettings ? _settings.MainDbConnectionInfo : _settings.ParamDbConnectionInfo;
             db_label.Text = $@"Server: {paramConnectionInfo.Server}{(paramConnectionInfo.Database.Length > 0 ? "  //  Database: " + paramConnectionInfo.Database : string.Empty)}";
 

--- a/src/SQLQueryStress/SqlControl.xaml.cs
+++ b/src/SQLQueryStress/SqlControl.xaml.cs
@@ -19,6 +19,11 @@ namespace SQLQueryStress
             set { AvalonEdit.Text = value; }
         }
 
+        public string SelectedText
+        {
+            get { return AvalonEdit.SelectedText; }
+        }
+
         private void SqlControl_OnLoaded(object sender, RoutedEventArgs e)
         {
             Stream stream = null;


### PR DESCRIPTION
Realizing it may be difficult for you to test this even though the stress test results make it pretty apparent what is being run with different selections. I just ended up writing to the visual studio output window to verify main query selection inside the go_button_Click method.

The behavior should be: 
- clicking go _with no text selection_ should run all text in text editor as main query
- clicking go _with text selection_ should only run the selected text as the main query