### PR TITLE
Provide details for connection failures

### DIFF
--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -178,7 +178,7 @@ namespace SQLQueryStress
                     return;
                 if (ex.Number != 4060)
                 {
-                    MessageBox.Show(Resources.ConnFail);
+                    MessageBox.Show(Resources.ConnFail + Environment.NewLine + Environment.NewLine + ex.Message);
 
                     if (dbComboboxParam == db_comboBox)
                     {


### PR DESCRIPTION
I kept getting _Connection Failed_ on one of the servers I was trying to test. Server error logs did not indicate why the connection attempt was rejected. Turned out this server forced encrypted connections but the certificate expired. This change will provide the detailed message from the SqlException to help diagnose the issue. 

![image](https://user-images.githubusercontent.com/18178902/212210118-40fd1255-db58-47d2-acc8-1fd412bbe90e.png)
