### PR TITLE
Remove calls to Thread.Sleep(0)

### DIFF
--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -390,7 +390,6 @@ namespace SQLQueryStress
                                     if (_statsComm != null)
                                     {
                                         _statsComm.ExecuteNonQuery();
-                                        Thread.Sleep(0);
                                         conn.InfoMessage += handler;
                                     }
                                 }
@@ -407,25 +406,20 @@ namespace SQLQueryStress
                                 if (_forceDataRetrieval)
                                 {
                                     var reader = _queryComm.ExecuteReader();
-                                    Thread.Sleep(0);
 
                                     do
                                     {
-                                        Thread.Sleep(0);
-
                                         while (!runCancelled && reader.Read())
                                         {
                                             //grab the first column to force the row down the pipe
                                             // ReSharper disable once UnusedVariable
                                             var x = reader[0];
-                                            Thread.Sleep(0);
                                         }
                                     } while (!runCancelled && reader.NextResult());
                                 }
                                 else
                                 {
                                     _queryComm.ExecuteNonQuery();
-                                    Thread.Sleep(0);
                                 }
 
                                 _sw.Stop();


### PR DESCRIPTION
These don't seem to help and can slow things down.

Considering following settings: 
Number of Iterations: 1
Number of Threads: 100
Force client retrieval of data: true

Setup:
```
DROP TABLE IF EXISTS [dbo].[LoadTest]

CREATE TABLE [dbo].[LoadTest](
	[A] [bigint] NOT NULL
) ON [PRIMARY]
GO

;WITH CTE AS ( SELECT A FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8)) X(A) )
INSERT INTO [dbo].[LoadTest]
SELECT 1 FROM CTE AS CTE1
CROSS JOIN CTE AS CTE2
CROSS JOIN CTE AS CTE3
CROSS JOIN CTE AS CTE4
CROSS JOIN CTE AS CTE5
CROSS JOIN CTE AS CTE6
CROSS JOIN CTE AS CTE7
CROSS JOIN CTE AS CTE8;
```

Testing following query:` SELECT TOP 1000000 * FROM [dbo].[LoadTest] WITH (NOLOCK)`

Duration without my changes: 35 s
with my changes: 5 s

As is currently the tool seems to struggle with consuming larger volumes of data produced by SQL Server. From SQL Server side I can see ASYNC_NETWORK_IO waits.

Tried to find scenario where my changes make things worse. Tried following:
```
SELECT 1 
SELECT COUNT(1) FROM [dbo].[LoadTest] WITH (NOLOCK)

```
All these seemed to be unaffected by my changes.