### PR TITLE
Use correct params for MessageBox.Show(); fix typos

### DIFF
--- a/src/SQLQueryStress/AboutBox.Designer.cs
+++ b/src/SQLQueryStress/AboutBox.Designer.cs
@@ -28,155 +28,157 @@ namespace SQLQueryStress
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutBox));
-            this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.logoPictureBox = new System.Windows.Forms.PictureBox();
-            this.labelProductName = new System.Windows.Forms.Label();
-            this.labelVersion = new System.Windows.Forms.Label();
-            this.labelCopyright = new System.Windows.Forms.Label();
-            this.labelCompanyName = new System.Windows.Forms.Label();
-            this.textBoxDescription = new System.Windows.Forms.TextBox();
-            this.okButton = new System.Windows.Forms.Button();
-            this.tableLayoutPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).BeginInit();
-            this.SuspendLayout();
+            tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            logoPictureBox = new System.Windows.Forms.PictureBox();
+            labelProductName = new System.Windows.Forms.Label();
+            labelVersion = new System.Windows.Forms.Label();
+            labelCopyright = new System.Windows.Forms.Label();
+            labelCompanyName = new System.Windows.Forms.Label();
+            textBoxDescription = new System.Windows.Forms.TextBox();
+            okButton = new System.Windows.Forms.Button();
+            tableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)logoPictureBox).BeginInit();
+            SuspendLayout();
             // 
             // tableLayoutPanel
             // 
-            this.tableLayoutPanel.ColumnCount = 2;
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 67F));
-            this.tableLayoutPanel.Controls.Add(this.logoPictureBox, 0, 0);
-            this.tableLayoutPanel.Controls.Add(this.labelProductName, 1, 0);
-            this.tableLayoutPanel.Controls.Add(this.labelVersion, 1, 1);
-            this.tableLayoutPanel.Controls.Add(this.labelCopyright, 1, 2);
-            this.tableLayoutPanel.Controls.Add(this.labelCompanyName, 1, 3);
-            this.tableLayoutPanel.Controls.Add(this.textBoxDescription, 1, 4);
-            this.tableLayoutPanel.Controls.Add(this.okButton, 1, 5);
-            this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel.Location = new System.Drawing.Point(9, 9);
-            this.tableLayoutPanel.Name = "tableLayoutPanel";
-            this.tableLayoutPanel.RowCount = 6;
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-            this.tableLayoutPanel.Size = new System.Drawing.Size(417, 265);
-            this.tableLayoutPanel.TabIndex = 0;
+            tableLayoutPanel.ColumnCount = 2;
+            tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33F));
+            tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 67F));
+            tableLayoutPanel.Controls.Add(logoPictureBox, 0, 0);
+            tableLayoutPanel.Controls.Add(labelProductName, 1, 0);
+            tableLayoutPanel.Controls.Add(labelVersion, 1, 1);
+            tableLayoutPanel.Controls.Add(labelCopyright, 1, 2);
+            tableLayoutPanel.Controls.Add(labelCompanyName, 1, 3);
+            tableLayoutPanel.Controls.Add(textBoxDescription, 1, 4);
+            tableLayoutPanel.Controls.Add(okButton, 1, 5);
+            tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel.Location = new System.Drawing.Point(12, 14);
+            tableLayoutPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            tableLayoutPanel.Name = "tableLayoutPanel";
+            tableLayoutPanel.RowCount = 6;
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            tableLayoutPanel.Size = new System.Drawing.Size(556, 407);
+            tableLayoutPanel.TabIndex = 0;
             // 
             // logoPictureBox
             // 
-            this.logoPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.logoPictureBox.Image = ((System.Drawing.Image)(resources.GetObject("logoPictureBox.Image")));
-            this.logoPictureBox.Location = new System.Drawing.Point(3, 3);
-            this.logoPictureBox.Name = "logoPictureBox";
-            this.tableLayoutPanel.SetRowSpan(this.logoPictureBox, 6);
-            this.logoPictureBox.Size = new System.Drawing.Size(131, 259);
-            this.logoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.logoPictureBox.TabIndex = 12;
-            this.logoPictureBox.TabStop = false;
+            logoPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            logoPictureBox.Image = (System.Drawing.Image)resources.GetObject("logoPictureBox.Image");
+            logoPictureBox.Location = new System.Drawing.Point(4, 5);
+            logoPictureBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            logoPictureBox.Name = "logoPictureBox";
+            tableLayoutPanel.SetRowSpan(logoPictureBox, 6);
+            logoPictureBox.Size = new System.Drawing.Size(175, 397);
+            logoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            logoPictureBox.TabIndex = 12;
+            logoPictureBox.TabStop = false;
             // 
             // labelProductName
             // 
-            this.labelProductName.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelProductName.Location = new System.Drawing.Point(143, 0);
-            this.labelProductName.Margin = new System.Windows.Forms.Padding(6, 0, 3, 0);
-            this.labelProductName.MaximumSize = new System.Drawing.Size(0, 17);
-            this.labelProductName.Name = "labelProductName";
-            this.labelProductName.Size = new System.Drawing.Size(271, 17);
-            this.labelProductName.TabIndex = 19;
-            this.labelProductName.Text = "SQLQueryStress";
-            this.labelProductName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            labelProductName.Dock = System.Windows.Forms.DockStyle.Fill;
+            labelProductName.Location = new System.Drawing.Point(191, 0);
+            labelProductName.Margin = new System.Windows.Forms.Padding(8, 0, 4, 0);
+            labelProductName.MaximumSize = new System.Drawing.Size(0, 26);
+            labelProductName.Name = "labelProductName";
+            labelProductName.Size = new System.Drawing.Size(361, 26);
+            labelProductName.TabIndex = 19;
+            labelProductName.Text = "SQLQueryStress";
+            labelProductName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // labelVersion
             // 
-            this.labelVersion.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelVersion.Location = new System.Drawing.Point(143, 26);
-            this.labelVersion.Margin = new System.Windows.Forms.Padding(6, 0, 3, 0);
-            this.labelVersion.MaximumSize = new System.Drawing.Size(0, 17);
-            this.labelVersion.Name = "labelVersion";
-            this.labelVersion.Size = new System.Drawing.Size(271, 17);
-            this.labelVersion.TabIndex = 0;
-            this.labelVersion.Text = "Version 0.0.1";
-            this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            labelVersion.Dock = System.Windows.Forms.DockStyle.Fill;
+            labelVersion.Location = new System.Drawing.Point(191, 40);
+            labelVersion.Margin = new System.Windows.Forms.Padding(8, 0, 4, 0);
+            labelVersion.MaximumSize = new System.Drawing.Size(0, 26);
+            labelVersion.Name = "labelVersion";
+            labelVersion.Size = new System.Drawing.Size(361, 26);
+            labelVersion.TabIndex = 0;
+            labelVersion.Text = "Version 0.0.1";
+            labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // labelCopyright
             // 
-            this.labelCopyright.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelCopyright.Location = new System.Drawing.Point(143, 52);
-            this.labelCopyright.Margin = new System.Windows.Forms.Padding(6, 0, 3, 0);
-            this.labelCopyright.MaximumSize = new System.Drawing.Size(0, 17);
-            this.labelCopyright.Name = "labelCopyright";
-            this.labelCopyright.Size = new System.Drawing.Size(271, 17);
-            this.labelCopyright.TabIndex = 21;
-            this.labelCopyright.Text = "Copyright Adam Machanic 2006";
-            this.labelCopyright.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            labelCopyright.Dock = System.Windows.Forms.DockStyle.Fill;
+            labelCopyright.Location = new System.Drawing.Point(191, 80);
+            labelCopyright.Margin = new System.Windows.Forms.Padding(8, 0, 4, 0);
+            labelCopyright.MaximumSize = new System.Drawing.Size(0, 26);
+            labelCopyright.Name = "labelCopyright";
+            labelCopyright.Size = new System.Drawing.Size(361, 26);
+            labelCopyright.TabIndex = 21;
+            labelCopyright.Text = "Copyright Adam Machanic 2006";
+            labelCopyright.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // labelCompanyName
             // 
-            this.labelCompanyName.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelCompanyName.Location = new System.Drawing.Point(143, 78);
-            this.labelCompanyName.Margin = new System.Windows.Forms.Padding(6, 0, 3, 0);
-            this.labelCompanyName.MaximumSize = new System.Drawing.Size(0, 17);
-            this.labelCompanyName.Name = "labelCompanyName";
-            this.labelCompanyName.Size = new System.Drawing.Size(271, 17);
-            this.labelCompanyName.TabIndex = 22;
-            this.labelCompanyName.Text = "Company Name";
-            this.labelCompanyName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            labelCompanyName.Dock = System.Windows.Forms.DockStyle.Fill;
+            labelCompanyName.Location = new System.Drawing.Point(191, 120);
+            labelCompanyName.Margin = new System.Windows.Forms.Padding(8, 0, 4, 0);
+            labelCompanyName.MaximumSize = new System.Drawing.Size(0, 26);
+            labelCompanyName.Name = "labelCompanyName";
+            labelCompanyName.Size = new System.Drawing.Size(361, 26);
+            labelCompanyName.TabIndex = 22;
+            labelCompanyName.Text = "Company Name";
+            labelCompanyName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // textBoxDescription
             // 
-            this.textBoxDescription.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.textBoxDescription.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textBoxDescription.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBoxDescription.ForeColor = System.Drawing.SystemColors.ActiveCaption;
-            this.textBoxDescription.Location = new System.Drawing.Point(143, 107);
-            this.textBoxDescription.Margin = new System.Windows.Forms.Padding(6, 3, 3, 3);
-            this.textBoxDescription.Multiline = true;
-            this.textBoxDescription.Name = "textBoxDescription";
-            this.textBoxDescription.ReadOnly = true;
-            this.textBoxDescription.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.textBoxDescription.Size = new System.Drawing.Size(271, 126);
-            this.textBoxDescription.TabIndex = 23;
-            this.textBoxDescription.TabStop = false;
-            this.textBoxDescription.Text = "Please visit https://github.com/ErikEJ/SqlQueryStress for documentation and updat" +
-    "es!";
-            this.textBoxDescription.Click += new System.EventHandler(this.textBoxDescription_Click);
+            textBoxDescription.Cursor = System.Windows.Forms.Cursors.Hand;
+            textBoxDescription.Dock = System.Windows.Forms.DockStyle.Fill;
+            textBoxDescription.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            textBoxDescription.ForeColor = System.Drawing.SystemColors.ActiveCaption;
+            textBoxDescription.Location = new System.Drawing.Point(191, 165);
+            textBoxDescription.Margin = new System.Windows.Forms.Padding(8, 5, 4, 5);
+            textBoxDescription.Multiline = true;
+            textBoxDescription.Name = "textBoxDescription";
+            textBoxDescription.ReadOnly = true;
+            textBoxDescription.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            textBoxDescription.Size = new System.Drawing.Size(361, 193);
+            textBoxDescription.TabIndex = 23;
+            textBoxDescription.TabStop = false;
+            textBoxDescription.Text = "Please visit https://github.com/ErikEJ/SqlQueryStress for documentation and updates!";
+            textBoxDescription.Click += textBoxDescription_Click;
             // 
             // okButton
             // 
-            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.okButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.okButton.Location = new System.Drawing.Point(339, 239);
-            this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(75, 23);
-            this.okButton.TabIndex = 24;
-            this.okButton.Text = "&OK";
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            okButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            okButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            okButton.Location = new System.Drawing.Point(452, 368);
+            okButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            okButton.Name = "okButton";
+            okButton.Size = new System.Drawing.Size(100, 34);
+            okButton.TabIndex = 24;
+            okButton.Text = "&OK";
+            okButton.Click += okButton_Click;
             // 
             // AboutBox
             // 
-            this.AcceptButton = this.okButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.okButton;
-            this.ClientSize = new System.Drawing.Size(435, 283);
-            this.Controls.Add(this.tableLayoutPanel);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "AboutBox";
-            this.Padding = new System.Windows.Forms.Padding(9);
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "AboutBox";
-            this.tableLayoutPanel.ResumeLayout(false);
-            this.tableLayoutPanel.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).EndInit();
-            this.ResumeLayout(false);
-
+            AcceptButton = okButton;
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = okButton;
+            ClientSize = new System.Drawing.Size(580, 435);
+            Controls.Add(tableLayoutPanel);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "AboutBox";
+            Padding = new System.Windows.Forms.Padding(12, 14, 12, 14);
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "AboutBox";
+            tableLayoutPanel.ResumeLayout(false);
+            tableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)logoPictureBox).EndInit();
+            ResumeLayout(false);
         }
 
         #endregion

--- a/src/SQLQueryStress/AboutBox.resx
+++ b/src/SQLQueryStress/AboutBox.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -186,7 +186,7 @@ namespace SQLQueryStress
                     return;
                 if (ex.Number != 4060)
                 {
-                    MessageBox.Show(Resources.ConnFail + Environment.NewLine + ex.Message);
+                    MessageBox.Show($"{Resources.ConnFail}{Environment.NewLine}{ex.Message}", Resources.AppTitle);
 
                     if (dbComboboxParam == db_comboBox)
                     {
@@ -323,7 +323,7 @@ namespace SQLQueryStress
         {
             pm_saveLocalSettings();
 
-            MessageBox.Show(_localParamConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail);
+            MessageBox.Show(_localParamConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail, Resources.AppTitle);
         }
 
         private void SaveLocalSettings()
@@ -396,7 +396,7 @@ namespace SQLQueryStress
         {
             SaveLocalSettings();
 
-            MessageBox.Show(_localMainConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail);
+            MessageBox.Show(_localMainConnectionInfo.TestConnection() ? Resources.ConnSucc : Resources.ConnFail, Resources.AppTitle);
         }
 
 

--- a/src/SQLQueryStress/FormMain.Designer.cs
+++ b/src/SQLQueryStress/FormMain.Designer.cs
@@ -1,3 +1,4 @@
+using SQLQueryStress.Properties;
 using System.Windows.Forms;
 
 namespace SQLQueryStress
@@ -16,14 +17,14 @@ namespace SQLQueryStress
         protected override void Dispose(bool disposing)
         {
             if (backgroundWorker1.CancellationPending)
-                System.Windows.Forms.MessageBox.Show("Please wait while background threads are cancelled.");
+                System.Windows.Forms.MessageBox.Show("Please wait while background threads are canceled.", Resources.AppTitle);
             else if (backgroundWorker1.IsBusy)
             {
                 if (System.Windows.Forms.MessageBox.Show(
-                "A test is currently running.  Cancel and shut down?",
-                "Really Close?",
-                System.Windows.Forms.MessageBoxButtons.YesNo,
-                System.Windows.Forms.MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes)
+                    "Really Close? A test is currently running.  Cancel and shut down?",
+                    Resources.AppTitle,
+                    System.Windows.Forms.MessageBoxButtons.YesNo,
+                    System.Windows.Forms.MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes)
                 {
                     cancel_button_Click(new System.String(' ', 0), null);
                 }

--- a/src/SQLQueryStress/FormMain.cs
+++ b/src/SQLQueryStress/FormMain.cs
@@ -300,7 +300,7 @@ namespace SQLQueryStress
         {
             if (!_settings.MainDbConnectionInfo.TestConnection())
             {
-                MessageBox.Show(Resources.MustSetValidDbConnInfo);
+                MessageBox.Show(Resources.MustSetValidDbConnInfo, Resources.AppTitle);
                 return;
             }
 
@@ -378,7 +378,7 @@ namespace SQLQueryStress
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"{Resources.ErrLoadingSettings}: {ex.Message}");
+                MessageBox.Show($"{Resources.ErrLoadingSettings}: {ex.Message}", Resources.AppTitle);
             }
 
             sqlControl1.Text = _settings.MainQuery;
@@ -414,7 +414,7 @@ namespace SQLQueryStress
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"{Resources.ErrorSavingSettings}: {ex.Message}");
+                MessageBox.Show($"{Resources.ErrorSavingSettings}: {ex.Message}", Resources.AppTitle);
             }
         }
 
@@ -491,7 +491,7 @@ namespace SQLQueryStress
         {
             if (!_settings.MainDbConnectionInfo.TestConnection())
             {
-                MessageBox.Show(Resources.MustSetValidDbConnInfo);
+                MessageBox.Show(Resources.MustSetValidDbConnInfo, Resources.AppTitle);
                 return;
             }
 
@@ -499,20 +499,22 @@ namespace SQLQueryStress
 
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC DROPCLEANBUFFERS")
                 ? "Buffers cleared"
-                : "Errors encountered");
+                : "Errors encountered",
+                Resources.AppTitle);
         }
 
         private void btnFreeCache_Click(object sender, EventArgs e)
         {
             if (!_settings.MainDbConnectionInfo.TestConnection())
             {
-                MessageBox.Show(Resources.MustSetValidDbConnInfo);
+                MessageBox.Show(Resources.MustSetValidDbConnInfo, Resources.AppTitle);
                 return;
             }
 
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC FREEPROCCACHE")
                 ? "Cache freed"
-                : "Errors encountered");
+                : "Errors encountered",
+                Resources.AppTitle);
         }
 
 
@@ -540,8 +542,7 @@ namespace SQLQueryStress
             catch (Exception)
             {
                 MessageBox
-                    .Show("Error While Saving BenchMark",
-                    $"There was an error saving the benchmark to '{fileName}', make sure you have write privileges to that path");
+                    .Show($"Error While Saving BenchMark: There was an error saving the benchmark to '{fileName}', make sure you have write privileges to that path", Resources.AppTitle);
             }
         }
 

--- a/src/SQLQueryStress/ParamWindow.cs
+++ b/src/SQLQueryStress/ParamWindow.cs
@@ -108,7 +108,7 @@ namespace SQLQueryStress
 
             if (!dbInfo.TestConnection())
             {
-                MessageBox.Show(Resources.MustSetValidDatabaseConn);
+                MessageBox.Show(Resources.MustSetValidDatabaseConn, Resources.AppTitle);
                 return;
             }
 
@@ -124,7 +124,7 @@ namespace SQLQueryStress
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message);
+                MessageBox.Show(ex.Message, Resources.AppTitle);
             }
 
             if (reader != null)
@@ -181,7 +181,7 @@ namespace SQLQueryStress
         private string[] GetParams()
         {
             //Find all SQL variables:
-            //'@', preceeded by '=', ',', or any white space character
+            //'@', preceded by '=', ',', or any white space character
             //then, any "word" character
             //Finally, '=', ',', or any white space, repeated 0 or more times 
             //(in the case of end-of-string, will be 0 times)
@@ -197,7 +197,7 @@ namespace SQLQueryStress
             }
 
             if (output.Count == 0)
-                MessageBox.Show(Resources.NoVarsWereIdentified);
+                MessageBox.Show(Resources.NoVarsWereIdentified, Resources.AppTitle);
 
             return output.ToArray();
         }

--- a/src/SQLQueryStress/Properties/Resources.Designer.cs
+++ b/src/SQLQueryStress/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SQLQueryStress.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,15 @@ namespace SQLQueryStress.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SqlQueryStress.
+        /// </summary>
+        internal static string AppTitle {
+            get {
+                return ResourceManager.GetString("AppTitle", resourceCulture);
             }
         }
         

--- a/src/SQLQueryStress/Properties/Resources.resx
+++ b/src/SQLQueryStress/Properties/Resources.resx
@@ -157,4 +157,7 @@
   <data name="TextFiles" xml:space="preserve">
     <value>Text Files (*.txt)|*.txt</value>
   </data>
+  <data name="AppTitle" xml:space="preserve">
+    <value>SqlQueryStress</value>
+  </data>
 </root>


### PR DESCRIPTION
This checkin adds titles to message boxes, which were previously blank. A message box title should identify the app which created the message box.

A couple of `MessageBox` calls incorrectly used the title parameter for parts of the message.

Also fixes a couple of typos while driving by.

See issue #161, which identifies the problem with un-titled message boxes.