### PR TITLE
add a "trust server certificate" checkbox to allow using self-signed certs

### DIFF
--- a/src/SQLQueryStress/ConnectionInfo.cs
+++ b/src/SQLQueryStress/ConnectionInfo.cs
@@ -29,6 +29,9 @@ namespace SQLQueryStress
         [DataMember]
         public string EncryptOption { get; set; }
 
+        [DataMember]
+        public bool TrustServerCertificate { get; set; }
+
         [IgnoreDataMember]
         public SqlConnectionEncryptOption Encrypt 
         {
@@ -98,7 +101,7 @@ namespace SQLQueryStress
         {
             get
             {
-                var build = new SqlConnectionStringBuilder { DataSource = Server, IntegratedSecurity = IntegratedAuth, ApplicationName = "SQLQueryStress", ApplicationIntent = ApplicationIntent };
+                var build = new SqlConnectionStringBuilder { DataSource = Server, IntegratedSecurity = IntegratedAuth, ApplicationName = "SQLQueryStress", ApplicationIntent = ApplicationIntent, TrustServerCertificate = TrustServerCertificate };
                 if (!IntegratedAuth && !AzureMFA)
                 {
                     build.UserID = Login;

--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -28,535 +28,546 @@ namespace SQLQueryStress
         /// </summary>
         private void InitializeComponent()
         {
-			this.label1 = new System.Windows.Forms.Label();
-			this.server_textBox = new System.Windows.Forms.TextBox();
-			this.authentication_comboBox = new System.Windows.Forms.ComboBox();
-			this.login_textBox = new System.Windows.Forms.TextBox();
-			this.password_textBox = new System.Windows.Forms.TextBox();
-			this.label2 = new System.Windows.Forms.Label();
-			this.label3 = new System.Windows.Forms.Label();
-			this.label4 = new System.Windows.Forms.Label();
-			this.cancel_button = new System.Windows.Forms.Button();
-			this.test_button = new System.Windows.Forms.Button();
-			this.ok_button = new System.Windows.Forms.Button();
-			this.db_comboBox = new System.Windows.Forms.ComboBox();
-			this.label5 = new System.Windows.Forms.Label();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.additionalParameters_textBox = new System.Windows.Forms.TextBox();
-			this.label13 = new System.Windows.Forms.Label();
-			this.encrypt_Combo = new System.Windows.Forms.ComboBox();
-			this.label11 = new System.Windows.Forms.Label();
-			this.appintent_combo = new System.Windows.Forms.ComboBox();
-			this.appintent_check = new System.Windows.Forms.CheckBox();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
-			this.pm_additionalParameters_textBox = new System.Windows.Forms.TextBox();
-			this.pm_encrypt_Combo = new System.Windows.Forms.ComboBox();
-			this.label14 = new System.Windows.Forms.Label();
-			this.label12 = new System.Windows.Forms.Label();
-			this.pm_appintent_combo = new System.Windows.Forms.ComboBox();
-			this.pm_appintent_check = new System.Windows.Forms.CheckBox();
-			this.pm_test_button = new System.Windows.Forms.Button();
-			this.shareSettings_checkBox = new System.Windows.Forms.CheckBox();
-			this.pm_db_comboBox = new System.Windows.Forms.ComboBox();
-			this.label6 = new System.Windows.Forms.Label();
-			this.pm_password_textBox = new System.Windows.Forms.TextBox();
-			this.label7 = new System.Windows.Forms.Label();
-			this.pm_server_textBox = new System.Windows.Forms.TextBox();
-			this.label8 = new System.Windows.Forms.Label();
-			this.label9 = new System.Windows.Forms.Label();
-			this.pm_login_textBox = new System.Windows.Forms.TextBox();
-			this.pm_authentication_comboBox = new System.Windows.Forms.ComboBox();
-			this.label10 = new System.Windows.Forms.Label();
-			this.groupBox1.SuspendLayout();
-			this.groupBox2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label1.Location = new System.Drawing.Point(8, 60);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(56, 17);
-			this.label1.TabIndex = 0;
-			this.label1.Text = "Server";
-			// 
-			// server_textBox
-			// 
-			this.server_textBox.Location = new System.Drawing.Point(13, 85);
-			this.server_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.server_textBox.Name = "server_textBox";
-			this.server_textBox.Size = new System.Drawing.Size(306, 27);
-			this.server_textBox.TabIndex = 0;
-			// 
-			// authentication_comboBox
-			// 
-			this.authentication_comboBox.FormattingEnabled = true;
-			this.authentication_comboBox.Items.AddRange(new object[] {
-            "Integrated Authentication",
-            "SQL Server Authentication",
-            "Azure Active Directory - Universal with MFA"});
-			this.authentication_comboBox.Location = new System.Drawing.Point(13, 145);
-			this.authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.authentication_comboBox.Name = "authentication_comboBox";
-			this.authentication_comboBox.Size = new System.Drawing.Size(306, 28);
-			this.authentication_comboBox.TabIndex = 1;
-			// 
-			// login_textBox
-			// 
-			this.login_textBox.Location = new System.Drawing.Point(13, 206);
-			this.login_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.login_textBox.Name = "login_textBox";
-			this.login_textBox.Size = new System.Drawing.Size(306, 27);
-			this.login_textBox.TabIndex = 2;
-			// 
-			// password_textBox
-			// 
-			this.password_textBox.Location = new System.Drawing.Point(13, 266);
-			this.password_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.password_textBox.Name = "password_textBox";
-			this.password_textBox.Size = new System.Drawing.Size(306, 27);
-			this.password_textBox.TabIndex = 3;
-			this.password_textBox.UseSystemPasswordChar = true;
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label2.Location = new System.Drawing.Point(13, 242);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(77, 17);
-			this.label2.TabIndex = 5;
-			this.label2.Text = "Password";
-			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label3.Location = new System.Drawing.Point(8, 182);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(48, 17);
-			this.label3.TabIndex = 6;
-			this.label3.Text = "Login";
-			// 
-			// label4
-			// 
-			this.label4.AutoSize = true;
-			this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label4.Location = new System.Drawing.Point(8, 120);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(112, 17);
-			this.label4.TabIndex = 7;
-			this.label4.Text = "Authentication";
-			// 
-			// cancel_button
-			// 
-			this.cancel_button.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancel_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.cancel_button.Location = new System.Drawing.Point(574, 659);
-			this.cancel_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.cancel_button.Name = "cancel_button";
-			this.cancel_button.Size = new System.Drawing.Size(106, 35);
-			this.cancel_button.TabIndex = 3;
-			this.cancel_button.Text = "Cancel";
-			this.cancel_button.UseVisualStyleBackColor = true;
-			this.cancel_button.Click += new System.EventHandler(this.cancel_button_Click);
-			// 
-			// test_button
-			// 
-			this.test_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.test_button.Location = new System.Drawing.Point(162, 573);
-			this.test_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.test_button.Name = "test_button";
-			this.test_button.Size = new System.Drawing.Size(160, 35);
-			this.test_button.TabIndex = 5;
-			this.test_button.Text = "Test Connection";
-			this.test_button.UseVisualStyleBackColor = true;
-			this.test_button.Click += new System.EventHandler(this.test_button_Click);
-			// 
-			// ok_button
-			// 
-			this.ok_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.ok_button.Location = new System.Drawing.Point(458, 659);
-			this.ok_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.ok_button.Name = "ok_button";
-			this.ok_button.Size = new System.Drawing.Size(106, 35);
-			this.ok_button.TabIndex = 2;
-			this.ok_button.Text = "OK";
-			this.ok_button.UseVisualStyleBackColor = true;
-			this.ok_button.Click += new System.EventHandler(this.ok_button_Click);
-			// 
-			// db_comboBox
-			// 
-			this.db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-			this.db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-			this.db_comboBox.FormattingEnabled = true;
-			this.db_comboBox.Location = new System.Drawing.Point(13, 326);
-			this.db_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.db_comboBox.Name = "db_comboBox";
-			this.db_comboBox.Size = new System.Drawing.Size(306, 28);
-			this.db_comboBox.TabIndex = 4;
-			// 
-			// label5
-			// 
-			this.label5.AutoSize = true;
-			this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label5.Location = new System.Drawing.Point(8, 302);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(134, 17);
-			this.label5.TabIndex = 12;
-			this.label5.Text = "Default Database";
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.additionalParameters_textBox);
-			this.groupBox1.Controls.Add(this.label13);
-			this.groupBox1.Controls.Add(this.encrypt_Combo);
-			this.groupBox1.Controls.Add(this.label11);
-			this.groupBox1.Controls.Add(this.appintent_combo);
-			this.groupBox1.Controls.Add(this.appintent_check);
-			this.groupBox1.Controls.Add(this.db_comboBox);
-			this.groupBox1.Controls.Add(this.label5);
-			this.groupBox1.Controls.Add(this.password_textBox);
-			this.groupBox1.Controls.Add(this.test_button);
-			this.groupBox1.Controls.Add(this.label2);
-			this.groupBox1.Controls.Add(this.server_textBox);
-			this.groupBox1.Controls.Add(this.label1);
-			this.groupBox1.Controls.Add(this.label4);
-			this.groupBox1.Controls.Add(this.login_textBox);
-			this.groupBox1.Controls.Add(this.authentication_comboBox);
-			this.groupBox1.Controls.Add(this.label3);
-			this.groupBox1.Location = new System.Drawing.Point(16, 18);
-			this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.groupBox1.Size = new System.Drawing.Size(328, 629);
-			this.groupBox1.TabIndex = 0;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Main Load Settings";
-			// 
-			// additionalParameters_textBox
-			// 
-			this.additionalParameters_textBox.Location = new System.Drawing.Point(13, 505);
-			this.additionalParameters_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.additionalParameters_textBox.Multiline = true;
-			this.additionalParameters_textBox.Name = "additionalParameters_textBox";
-			this.additionalParameters_textBox.Size = new System.Drawing.Size(306, 54);
-			this.additionalParameters_textBox.TabIndex = 19;
-			// 
-			// label13
-			// 
-			this.label13.AutoSize = true;
-			this.label13.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label13.Location = new System.Drawing.Point(13, 483);
-			this.label13.Name = "label13";
-			this.label13.Size = new System.Drawing.Size(168, 17);
-			this.label13.TabIndex = 18;
-			this.label13.Text = "Additional Parameters";
-			// 
-			// encrypt_Combo
-			// 
-			this.encrypt_Combo.FormattingEnabled = true;
-			this.encrypt_Combo.Items.AddRange(new object[] {
-            "False",
-            "True",
-            "Strict"});
-			this.encrypt_Combo.Location = new System.Drawing.Point(13, 452);
-			this.encrypt_Combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.encrypt_Combo.Name = "encrypt_Combo";
-			this.encrypt_Combo.Size = new System.Drawing.Size(306, 28);
-			this.encrypt_Combo.TabIndex = 17;
-			// 
-			// label11
-			// 
-			this.label11.AutoSize = true;
-			this.label11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label11.Location = new System.Drawing.Point(8, 426);
-			this.label11.Name = "label11";
-			this.label11.Size = new System.Drawing.Size(63, 17);
-			this.label11.TabIndex = 16;
-			this.label11.Text = "Encrypt";
-			// 
-			// appintent_combo
-			// 
-			this.appintent_combo.Enabled = false;
-			this.appintent_combo.FormattingEnabled = true;
-			this.appintent_combo.Items.AddRange(new object[] {
-            "ReadWrite ",
-            "ReadOnly"});
-			this.appintent_combo.Location = new System.Drawing.Point(13, 394);
-			this.appintent_combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.appintent_combo.Name = "appintent_combo";
-			this.appintent_combo.Size = new System.Drawing.Size(306, 28);
-			this.appintent_combo.TabIndex = 14;
-			// 
-			// appintent_check
-			// 
-			this.appintent_check.AutoSize = true;
-			this.appintent_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.appintent_check.Location = new System.Drawing.Point(13, 363);
-			this.appintent_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.appintent_check.Name = "appintent_check";
-			this.appintent_check.Size = new System.Drawing.Size(156, 21);
-			this.appintent_check.TabIndex = 13;
-			this.appintent_check.Text = "Application Intent";
-			this.appintent_check.UseVisualStyleBackColor = true;
-			this.appintent_check.CheckedChanged += new System.EventHandler(this.appintent_check_CheckedChanged);
-			// 
-			// groupBox2
-			// 
-			this.groupBox2.Controls.Add(this.pm_additionalParameters_textBox);
-			this.groupBox2.Controls.Add(this.pm_encrypt_Combo);
-			this.groupBox2.Controls.Add(this.label14);
-			this.groupBox2.Controls.Add(this.label12);
-			this.groupBox2.Controls.Add(this.pm_appintent_combo);
-			this.groupBox2.Controls.Add(this.pm_appintent_check);
-			this.groupBox2.Controls.Add(this.pm_test_button);
-			this.groupBox2.Controls.Add(this.shareSettings_checkBox);
-			this.groupBox2.Controls.Add(this.pm_db_comboBox);
-			this.groupBox2.Controls.Add(this.label6);
-			this.groupBox2.Controls.Add(this.pm_password_textBox);
-			this.groupBox2.Controls.Add(this.label7);
-			this.groupBox2.Controls.Add(this.pm_server_textBox);
-			this.groupBox2.Controls.Add(this.label8);
-			this.groupBox2.Controls.Add(this.label9);
-			this.groupBox2.Controls.Add(this.pm_login_textBox);
-			this.groupBox2.Controls.Add(this.pm_authentication_comboBox);
-			this.groupBox2.Controls.Add(this.label10);
-			this.groupBox2.Location = new System.Drawing.Point(352, 18);
-			this.groupBox2.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.groupBox2.Size = new System.Drawing.Size(328, 629);
-			this.groupBox2.TabIndex = 1;
-			this.groupBox2.TabStop = false;
-			this.groupBox2.Text = "Parameterization Settings";
-			// 
-			// pm_additionalParameters_textBox
-			// 
-			this.pm_additionalParameters_textBox.Location = new System.Drawing.Point(9, 505);
-			this.pm_additionalParameters_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_additionalParameters_textBox.Multiline = true;
-			this.pm_additionalParameters_textBox.Name = "pm_additionalParameters_textBox";
-			this.pm_additionalParameters_textBox.Size = new System.Drawing.Size(306, 54);
-			this.pm_additionalParameters_textBox.TabIndex = 21;
-			// 
-			// pm_encrypt_Combo
-			// 
-			this.pm_encrypt_Combo.FormattingEnabled = true;
-			this.pm_encrypt_Combo.Items.AddRange(new object[] {
-            "Optional",
-            "Mandatory",
-            "Strict"});
-			this.pm_encrypt_Combo.Location = new System.Drawing.Point(11, 452);
-			this.pm_encrypt_Combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.pm_encrypt_Combo.Name = "pm_encrypt_Combo";
-			this.pm_encrypt_Combo.Size = new System.Drawing.Size(306, 28);
-			this.pm_encrypt_Combo.TabIndex = 18;
-			// 
-			// label14
-			// 
-			this.label14.AutoSize = true;
-			this.label14.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label14.Location = new System.Drawing.Point(9, 483);
-			this.label14.Name = "label14";
-			this.label14.Size = new System.Drawing.Size(168, 17);
-			this.label14.TabIndex = 20;
-			this.label14.Text = "Additional Parameters";
-			// 
-			// label12
-			// 
-			this.label12.AutoSize = true;
-			this.label12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label12.Location = new System.Drawing.Point(9, 426);
-			this.label12.Name = "label12";
-			this.label12.Size = new System.Drawing.Size(63, 17);
-			this.label12.TabIndex = 18;
-			this.label12.Text = "Encrypt";
-			// 
-			// pm_appintent_combo
-			// 
-			this.pm_appintent_combo.Enabled = false;
-			this.pm_appintent_combo.FormattingEnabled = true;
-			this.pm_appintent_combo.Items.AddRange(new object[] {
-            "ReadWrite ",
-            "ReadOnly"});
-			this.pm_appintent_combo.Location = new System.Drawing.Point(11, 394);
-			this.pm_appintent_combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.pm_appintent_combo.Name = "pm_appintent_combo";
-			this.pm_appintent_combo.Size = new System.Drawing.Size(306, 28);
-			this.pm_appintent_combo.TabIndex = 16;
-			// 
-			// pm_appintent_check
-			// 
-			this.pm_appintent_check.AutoSize = true;
-			this.pm_appintent_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.pm_appintent_check.Location = new System.Drawing.Point(11, 363);
-			this.pm_appintent_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-			this.pm_appintent_check.Name = "pm_appintent_check";
-			this.pm_appintent_check.Size = new System.Drawing.Size(156, 21);
-			this.pm_appintent_check.TabIndex = 15;
-			this.pm_appintent_check.Text = "Application Intent";
-			this.pm_appintent_check.UseVisualStyleBackColor = true;
-			this.pm_appintent_check.CheckedChanged += new System.EventHandler(this.appintent_check_CheckedChanged);
-			// 
-			// pm_test_button
-			// 
-			this.pm_test_button.Enabled = false;
-			this.pm_test_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.pm_test_button.Location = new System.Drawing.Point(157, 573);
-			this.pm_test_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_test_button.Name = "pm_test_button";
-			this.pm_test_button.Size = new System.Drawing.Size(160, 35);
-			this.pm_test_button.TabIndex = 5;
-			this.pm_test_button.Text = "Test Connection";
-			this.pm_test_button.UseVisualStyleBackColor = true;
-			this.pm_test_button.Click += new System.EventHandler(this.pm_test_button_Click);
-			// 
-			// shareSettings_checkBox
-			// 
-			this.shareSettings_checkBox.AutoSize = true;
-			this.shareSettings_checkBox.Checked = true;
-			this.shareSettings_checkBox.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.shareSettings_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.shareSettings_checkBox.Location = new System.Drawing.Point(16, 29);
-			this.shareSettings_checkBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.shareSettings_checkBox.Name = "shareSettings_checkBox";
-			this.shareSettings_checkBox.Size = new System.Drawing.Size(223, 21);
-			this.shareSettings_checkBox.TabIndex = 13;
-			this.shareSettings_checkBox.Text = "Share Connection Settings";
-			this.shareSettings_checkBox.UseVisualStyleBackColor = true;
-			this.shareSettings_checkBox.CheckedChanged += new System.EventHandler(this.shareSettings_checkBox_CheckedChanged);
-			// 
-			// pm_db_comboBox
-			// 
-			this.pm_db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-			this.pm_db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-			this.pm_db_comboBox.Enabled = false;
-			this.pm_db_comboBox.FormattingEnabled = true;
-			this.pm_db_comboBox.Location = new System.Drawing.Point(13, 326);
-			this.pm_db_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_db_comboBox.Name = "pm_db_comboBox";
-			this.pm_db_comboBox.Size = new System.Drawing.Size(306, 28);
-			this.pm_db_comboBox.TabIndex = 4;
-			// 
-			// label6
-			// 
-			this.label6.AutoSize = true;
-			this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label6.Location = new System.Drawing.Point(8, 302);
-			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(134, 17);
-			this.label6.TabIndex = 12;
-			this.label6.Text = "Default Database";
-			// 
-			// pm_password_textBox
-			// 
-			this.pm_password_textBox.Enabled = false;
-			this.pm_password_textBox.Location = new System.Drawing.Point(13, 266);
-			this.pm_password_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_password_textBox.Name = "pm_password_textBox";
-			this.pm_password_textBox.Size = new System.Drawing.Size(306, 27);
-			this.pm_password_textBox.TabIndex = 3;
-			this.pm_password_textBox.UseSystemPasswordChar = true;
-			// 
-			// label7
-			// 
-			this.label7.AutoSize = true;
-			this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label7.Location = new System.Drawing.Point(13, 242);
-			this.label7.Name = "label7";
-			this.label7.Size = new System.Drawing.Size(77, 17);
-			this.label7.TabIndex = 5;
-			this.label7.Text = "Password";
-			// 
-			// pm_server_textBox
-			// 
-			this.pm_server_textBox.Enabled = false;
-			this.pm_server_textBox.Location = new System.Drawing.Point(13, 85);
-			this.pm_server_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_server_textBox.Name = "pm_server_textBox";
-			this.pm_server_textBox.Size = new System.Drawing.Size(306, 27);
-			this.pm_server_textBox.TabIndex = 0;
-			// 
-			// label8
-			// 
-			this.label8.AutoSize = true;
-			this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label8.Location = new System.Drawing.Point(8, 60);
-			this.label8.Name = "label8";
-			this.label8.Size = new System.Drawing.Size(56, 17);
-			this.label8.TabIndex = 0;
-			this.label8.Text = "Server";
-			// 
-			// label9
-			// 
-			this.label9.AutoSize = true;
-			this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label9.Location = new System.Drawing.Point(8, 120);
-			this.label9.Name = "label9";
-			this.label9.Size = new System.Drawing.Size(112, 17);
-			this.label9.TabIndex = 7;
-			this.label9.Text = "Authentication";
-			// 
-			// pm_login_textBox
-			// 
-			this.pm_login_textBox.Enabled = false;
-			this.pm_login_textBox.Location = new System.Drawing.Point(13, 206);
-			this.pm_login_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_login_textBox.Name = "pm_login_textBox";
-			this.pm_login_textBox.Size = new System.Drawing.Size(306, 27);
-			this.pm_login_textBox.TabIndex = 2;
-			// 
-			// pm_authentication_comboBox
-			// 
-			this.pm_authentication_comboBox.Enabled = false;
-			this.pm_authentication_comboBox.FormattingEnabled = true;
-			this.pm_authentication_comboBox.Items.AddRange(new object[] {
-            "Integrated Authentication",
-            "SQL Server Authentication",
-            "Azure Active Directory - Universal with MFA"});
-			this.pm_authentication_comboBox.Location = new System.Drawing.Point(13, 145);
-			this.pm_authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.pm_authentication_comboBox.Name = "pm_authentication_comboBox";
-			this.pm_authentication_comboBox.Size = new System.Drawing.Size(306, 28);
-			this.pm_authentication_comboBox.TabIndex = 1;
-			// 
-			// label10
-			// 
-			this.label10.AutoSize = true;
-			this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-			this.label10.Location = new System.Drawing.Point(8, 182);
-			this.label10.Name = "label10";
-			this.label10.Size = new System.Drawing.Size(48, 17);
-			this.label10.TabIndex = 6;
-			this.label10.Text = "Login";
-			// 
-			// DatabaseSelect
-			// 
-			this.AcceptButton = this.ok_button;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.cancel_button;
-			this.ClientSize = new System.Drawing.Size(698, 715);
-			this.Controls.Add(this.groupBox2);
-			this.Controls.Add(this.groupBox1);
-			this.Controls.Add(this.ok_button);
-			this.Controls.Add(this.cancel_button);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "DatabaseSelect";
-			this.ShowIcon = false;
-			this.ShowInTaskbar = false;
-			this.Text = "Database Select";
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
-			this.ResumeLayout(false);
-
+            label1 = new System.Windows.Forms.Label();
+            server_textBox = new System.Windows.Forms.TextBox();
+            authentication_comboBox = new System.Windows.Forms.ComboBox();
+            login_textBox = new System.Windows.Forms.TextBox();
+            password_textBox = new System.Windows.Forms.TextBox();
+            label2 = new System.Windows.Forms.Label();
+            label3 = new System.Windows.Forms.Label();
+            label4 = new System.Windows.Forms.Label();
+            cancel_button = new System.Windows.Forms.Button();
+            test_button = new System.Windows.Forms.Button();
+            ok_button = new System.Windows.Forms.Button();
+            db_comboBox = new System.Windows.Forms.ComboBox();
+            label5 = new System.Windows.Forms.Label();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            additionalParameters_textBox = new System.Windows.Forms.TextBox();
+            label13 = new System.Windows.Forms.Label();
+            encrypt_Combo = new System.Windows.Forms.ComboBox();
+            label11 = new System.Windows.Forms.Label();
+            appintent_combo = new System.Windows.Forms.ComboBox();
+            appintent_check = new System.Windows.Forms.CheckBox();
+            groupBox2 = new System.Windows.Forms.GroupBox();
+            pm_additionalParameters_textBox = new System.Windows.Forms.TextBox();
+            pm_encrypt_Combo = new System.Windows.Forms.ComboBox();
+            label14 = new System.Windows.Forms.Label();
+            label12 = new System.Windows.Forms.Label();
+            pm_appintent_combo = new System.Windows.Forms.ComboBox();
+            pm_appintent_check = new System.Windows.Forms.CheckBox();
+            pm_test_button = new System.Windows.Forms.Button();
+            shareSettings_checkBox = new System.Windows.Forms.CheckBox();
+            pm_db_comboBox = new System.Windows.Forms.ComboBox();
+            label6 = new System.Windows.Forms.Label();
+            pm_password_textBox = new System.Windows.Forms.TextBox();
+            label7 = new System.Windows.Forms.Label();
+            pm_server_textBox = new System.Windows.Forms.TextBox();
+            label8 = new System.Windows.Forms.Label();
+            label9 = new System.Windows.Forms.Label();
+            pm_login_textBox = new System.Windows.Forms.TextBox();
+            pm_authentication_comboBox = new System.Windows.Forms.ComboBox();
+            label10 = new System.Windows.Forms.Label();
+            trustcert_check = new System.Windows.Forms.CheckBox();
+            pm_trustcert_check = new System.Windows.Forms.CheckBox();
+            groupBox1.SuspendLayout();
+            groupBox2.SuspendLayout();
+            SuspendLayout();
+            // 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label1.Location = new System.Drawing.Point(8, 60);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(56, 17);
+            label1.TabIndex = 0;
+            label1.Text = "Server";
+            // 
+            // server_textBox
+            // 
+            server_textBox.Location = new System.Drawing.Point(13, 85);
+            server_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            server_textBox.Name = "server_textBox";
+            server_textBox.Size = new System.Drawing.Size(306, 27);
+            server_textBox.TabIndex = 0;
+            // 
+            // authentication_comboBox
+            // 
+            authentication_comboBox.FormattingEnabled = true;
+            authentication_comboBox.Items.AddRange(new object[] { "Integrated Authentication", "SQL Server Authentication", "Azure Active Directory - Universal with MFA" });
+            authentication_comboBox.Location = new System.Drawing.Point(13, 145);
+            authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            authentication_comboBox.Name = "authentication_comboBox";
+            authentication_comboBox.Size = new System.Drawing.Size(306, 28);
+            authentication_comboBox.TabIndex = 1;
+            // 
+            // login_textBox
+            // 
+            login_textBox.Location = new System.Drawing.Point(13, 206);
+            login_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            login_textBox.Name = "login_textBox";
+            login_textBox.Size = new System.Drawing.Size(306, 27);
+            login_textBox.TabIndex = 2;
+            // 
+            // password_textBox
+            // 
+            password_textBox.Location = new System.Drawing.Point(13, 266);
+            password_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            password_textBox.Name = "password_textBox";
+            password_textBox.Size = new System.Drawing.Size(306, 27);
+            password_textBox.TabIndex = 3;
+            password_textBox.UseSystemPasswordChar = true;
+            // 
+            // label2
+            // 
+            label2.AutoSize = true;
+            label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label2.Location = new System.Drawing.Point(13, 242);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(77, 17);
+            label2.TabIndex = 5;
+            label2.Text = "Password";
+            // 
+            // label3
+            // 
+            label3.AutoSize = true;
+            label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label3.Location = new System.Drawing.Point(8, 182);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(48, 17);
+            label3.TabIndex = 6;
+            label3.Text = "Login";
+            // 
+            // label4
+            // 
+            label4.AutoSize = true;
+            label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label4.Location = new System.Drawing.Point(8, 120);
+            label4.Name = "label4";
+            label4.Size = new System.Drawing.Size(112, 17);
+            label4.TabIndex = 7;
+            label4.Text = "Authentication";
+            // 
+            // cancel_button
+            // 
+            cancel_button.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            cancel_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            cancel_button.Location = new System.Drawing.Point(574, 685);
+            cancel_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            cancel_button.Name = "cancel_button";
+            cancel_button.Size = new System.Drawing.Size(106, 35);
+            cancel_button.TabIndex = 3;
+            cancel_button.Text = "Cancel";
+            cancel_button.UseVisualStyleBackColor = true;
+            cancel_button.Click += cancel_button_Click;
+            // 
+            // test_button
+            // 
+            test_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            test_button.Location = new System.Drawing.Point(159, 618);
+            test_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            test_button.Name = "test_button";
+            test_button.Size = new System.Drawing.Size(160, 35);
+            test_button.TabIndex = 5;
+            test_button.Text = "Test Connection";
+            test_button.UseVisualStyleBackColor = true;
+            test_button.Click += test_button_Click;
+            // 
+            // ok_button
+            // 
+            ok_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            ok_button.Location = new System.Drawing.Point(459, 685);
+            ok_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            ok_button.Name = "ok_button";
+            ok_button.Size = new System.Drawing.Size(106, 35);
+            ok_button.TabIndex = 2;
+            ok_button.Text = "OK";
+            ok_button.UseVisualStyleBackColor = true;
+            ok_button.Click += ok_button_Click;
+            // 
+            // db_comboBox
+            // 
+            db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            db_comboBox.FormattingEnabled = true;
+            db_comboBox.Location = new System.Drawing.Point(13, 326);
+            db_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            db_comboBox.Name = "db_comboBox";
+            db_comboBox.Size = new System.Drawing.Size(306, 28);
+            db_comboBox.TabIndex = 4;
+            // 
+            // label5
+            // 
+            label5.AutoSize = true;
+            label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label5.Location = new System.Drawing.Point(8, 302);
+            label5.Name = "label5";
+            label5.Size = new System.Drawing.Size(134, 17);
+            label5.TabIndex = 12;
+            label5.Text = "Default Database";
+            // 
+            // groupBox1
+            // 
+            groupBox1.Controls.Add(trustcert_check);
+            groupBox1.Controls.Add(additionalParameters_textBox);
+            groupBox1.Controls.Add(label13);
+            groupBox1.Controls.Add(encrypt_Combo);
+            groupBox1.Controls.Add(label11);
+            groupBox1.Controls.Add(appintent_combo);
+            groupBox1.Controls.Add(appintent_check);
+            groupBox1.Controls.Add(db_comboBox);
+            groupBox1.Controls.Add(label5);
+            groupBox1.Controls.Add(password_textBox);
+            groupBox1.Controls.Add(test_button);
+            groupBox1.Controls.Add(label2);
+            groupBox1.Controls.Add(server_textBox);
+            groupBox1.Controls.Add(label1);
+            groupBox1.Controls.Add(label4);
+            groupBox1.Controls.Add(login_textBox);
+            groupBox1.Controls.Add(authentication_comboBox);
+            groupBox1.Controls.Add(label3);
+            groupBox1.Location = new System.Drawing.Point(16, 18);
+            groupBox1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            groupBox1.Size = new System.Drawing.Size(328, 657);
+            groupBox1.TabIndex = 0;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Main Load Settings";
+            // 
+            // additionalParameters_textBox
+            // 
+            additionalParameters_textBox.Location = new System.Drawing.Point(13, 554);
+            additionalParameters_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            additionalParameters_textBox.Multiline = true;
+            additionalParameters_textBox.Name = "additionalParameters_textBox";
+            additionalParameters_textBox.Size = new System.Drawing.Size(306, 54);
+            additionalParameters_textBox.TabIndex = 19;
+            // 
+            // label13
+            // 
+            label13.AutoSize = true;
+            label13.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label13.Location = new System.Drawing.Point(13, 532);
+            label13.Name = "label13";
+            label13.Size = new System.Drawing.Size(168, 17);
+            label13.TabIndex = 18;
+            label13.Text = "Additional Parameters";
+            // 
+            // encrypt_Combo
+            // 
+            encrypt_Combo.FormattingEnabled = true;
+            encrypt_Combo.Items.AddRange(new object[] { "False", "True", "Strict" });
+            encrypt_Combo.Location = new System.Drawing.Point(13, 452);
+            encrypt_Combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            encrypt_Combo.Name = "encrypt_Combo";
+            encrypt_Combo.Size = new System.Drawing.Size(306, 28);
+            encrypt_Combo.TabIndex = 17;
+            // 
+            // label11
+            // 
+            label11.AutoSize = true;
+            label11.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label11.Location = new System.Drawing.Point(8, 426);
+            label11.Name = "label11";
+            label11.Size = new System.Drawing.Size(63, 17);
+            label11.TabIndex = 16;
+            label11.Text = "Encrypt";
+            // 
+            // appintent_combo
+            // 
+            appintent_combo.Enabled = false;
+            appintent_combo.FormattingEnabled = true;
+            appintent_combo.Items.AddRange(new object[] { "ReadWrite ", "ReadOnly" });
+            appintent_combo.Location = new System.Drawing.Point(13, 394);
+            appintent_combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            appintent_combo.Name = "appintent_combo";
+            appintent_combo.Size = new System.Drawing.Size(306, 28);
+            appintent_combo.TabIndex = 14;
+            // 
+            // appintent_check
+            // 
+            appintent_check.AutoSize = true;
+            appintent_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            appintent_check.Location = new System.Drawing.Point(13, 363);
+            appintent_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            appintent_check.Name = "appintent_check";
+            appintent_check.Size = new System.Drawing.Size(156, 21);
+            appintent_check.TabIndex = 13;
+            appintent_check.Text = "Application Intent";
+            appintent_check.UseVisualStyleBackColor = true;
+            appintent_check.CheckedChanged += appintent_check_CheckedChanged;
+            // 
+            // groupBox2
+            // 
+            groupBox2.Controls.Add(pm_trustcert_check);
+            groupBox2.Controls.Add(pm_additionalParameters_textBox);
+            groupBox2.Controls.Add(pm_encrypt_Combo);
+            groupBox2.Controls.Add(label14);
+            groupBox2.Controls.Add(label12);
+            groupBox2.Controls.Add(pm_appintent_combo);
+            groupBox2.Controls.Add(pm_appintent_check);
+            groupBox2.Controls.Add(pm_test_button);
+            groupBox2.Controls.Add(shareSettings_checkBox);
+            groupBox2.Controls.Add(pm_db_comboBox);
+            groupBox2.Controls.Add(label6);
+            groupBox2.Controls.Add(pm_password_textBox);
+            groupBox2.Controls.Add(label7);
+            groupBox2.Controls.Add(pm_server_textBox);
+            groupBox2.Controls.Add(label8);
+            groupBox2.Controls.Add(label9);
+            groupBox2.Controls.Add(pm_login_textBox);
+            groupBox2.Controls.Add(pm_authentication_comboBox);
+            groupBox2.Controls.Add(label10);
+            groupBox2.Location = new System.Drawing.Point(352, 18);
+            groupBox2.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            groupBox2.Size = new System.Drawing.Size(328, 657);
+            groupBox2.TabIndex = 1;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Parameterization Settings";
+            // 
+            // pm_additionalParameters_textBox
+            // 
+            pm_additionalParameters_textBox.Location = new System.Drawing.Point(11, 554);
+            pm_additionalParameters_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_additionalParameters_textBox.Multiline = true;
+            pm_additionalParameters_textBox.Name = "pm_additionalParameters_textBox";
+            pm_additionalParameters_textBox.Size = new System.Drawing.Size(306, 54);
+            pm_additionalParameters_textBox.TabIndex = 21;
+            // 
+            // pm_encrypt_Combo
+            // 
+            pm_encrypt_Combo.FormattingEnabled = true;
+            pm_encrypt_Combo.Items.AddRange(new object[] { "Optional", "Mandatory", "Strict" });
+            pm_encrypt_Combo.Location = new System.Drawing.Point(11, 452);
+            pm_encrypt_Combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            pm_encrypt_Combo.Name = "pm_encrypt_Combo";
+            pm_encrypt_Combo.Size = new System.Drawing.Size(306, 28);
+            pm_encrypt_Combo.TabIndex = 18;
+            // 
+            // label14
+            // 
+            label14.AutoSize = true;
+            label14.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label14.Location = new System.Drawing.Point(11, 532);
+            label14.Name = "label14";
+            label14.Size = new System.Drawing.Size(168, 17);
+            label14.TabIndex = 20;
+            label14.Text = "Additional Parameters";
+            // 
+            // label12
+            // 
+            label12.AutoSize = true;
+            label12.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label12.Location = new System.Drawing.Point(9, 426);
+            label12.Name = "label12";
+            label12.Size = new System.Drawing.Size(63, 17);
+            label12.TabIndex = 18;
+            label12.Text = "Encrypt";
+            // 
+            // pm_appintent_combo
+            // 
+            pm_appintent_combo.Enabled = false;
+            pm_appintent_combo.FormattingEnabled = true;
+            pm_appintent_combo.Items.AddRange(new object[] { "ReadWrite ", "ReadOnly" });
+            pm_appintent_combo.Location = new System.Drawing.Point(11, 394);
+            pm_appintent_combo.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            pm_appintent_combo.Name = "pm_appintent_combo";
+            pm_appintent_combo.Size = new System.Drawing.Size(306, 28);
+            pm_appintent_combo.TabIndex = 16;
+            // 
+            // pm_appintent_check
+            // 
+            pm_appintent_check.AutoSize = true;
+            pm_appintent_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            pm_appintent_check.Location = new System.Drawing.Point(11, 363);
+            pm_appintent_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            pm_appintent_check.Name = "pm_appintent_check";
+            pm_appintent_check.Size = new System.Drawing.Size(156, 21);
+            pm_appintent_check.TabIndex = 15;
+            pm_appintent_check.Text = "Application Intent";
+            pm_appintent_check.UseVisualStyleBackColor = true;
+            pm_appintent_check.CheckedChanged += appintent_check_CheckedChanged;
+            // 
+            // pm_test_button
+            // 
+            pm_test_button.Enabled = false;
+            pm_test_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            pm_test_button.Location = new System.Drawing.Point(157, 618);
+            pm_test_button.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_test_button.Name = "pm_test_button";
+            pm_test_button.Size = new System.Drawing.Size(160, 35);
+            pm_test_button.TabIndex = 5;
+            pm_test_button.Text = "Test Connection";
+            pm_test_button.UseVisualStyleBackColor = true;
+            pm_test_button.Click += pm_test_button_Click;
+            // 
+            // shareSettings_checkBox
+            // 
+            shareSettings_checkBox.AutoSize = true;
+            shareSettings_checkBox.Checked = true;
+            shareSettings_checkBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            shareSettings_checkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            shareSettings_checkBox.Location = new System.Drawing.Point(16, 29);
+            shareSettings_checkBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            shareSettings_checkBox.Name = "shareSettings_checkBox";
+            shareSettings_checkBox.Size = new System.Drawing.Size(223, 21);
+            shareSettings_checkBox.TabIndex = 13;
+            shareSettings_checkBox.Text = "Share Connection Settings";
+            shareSettings_checkBox.UseVisualStyleBackColor = true;
+            shareSettings_checkBox.CheckedChanged += shareSettings_checkBox_CheckedChanged;
+            // 
+            // pm_db_comboBox
+            // 
+            pm_db_comboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            pm_db_comboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            pm_db_comboBox.Enabled = false;
+            pm_db_comboBox.FormattingEnabled = true;
+            pm_db_comboBox.Location = new System.Drawing.Point(13, 326);
+            pm_db_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_db_comboBox.Name = "pm_db_comboBox";
+            pm_db_comboBox.Size = new System.Drawing.Size(306, 28);
+            pm_db_comboBox.TabIndex = 4;
+            // 
+            // label6
+            // 
+            label6.AutoSize = true;
+            label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label6.Location = new System.Drawing.Point(8, 298);
+            label6.Name = "label6";
+            label6.Size = new System.Drawing.Size(134, 17);
+            label6.TabIndex = 12;
+            label6.Text = "Default Database";
+            // 
+            // pm_password_textBox
+            // 
+            pm_password_textBox.Enabled = false;
+            pm_password_textBox.Location = new System.Drawing.Point(13, 266);
+            pm_password_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_password_textBox.Name = "pm_password_textBox";
+            pm_password_textBox.Size = new System.Drawing.Size(306, 27);
+            pm_password_textBox.TabIndex = 3;
+            pm_password_textBox.UseSystemPasswordChar = true;
+            // 
+            // label7
+            // 
+            label7.AutoSize = true;
+            label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label7.Location = new System.Drawing.Point(13, 242);
+            label7.Name = "label7";
+            label7.Size = new System.Drawing.Size(77, 17);
+            label7.TabIndex = 5;
+            label7.Text = "Password";
+            // 
+            // pm_server_textBox
+            // 
+            pm_server_textBox.Enabled = false;
+            pm_server_textBox.Location = new System.Drawing.Point(13, 85);
+            pm_server_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_server_textBox.Name = "pm_server_textBox";
+            pm_server_textBox.Size = new System.Drawing.Size(306, 27);
+            pm_server_textBox.TabIndex = 0;
+            // 
+            // label8
+            // 
+            label8.AutoSize = true;
+            label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label8.Location = new System.Drawing.Point(8, 60);
+            label8.Name = "label8";
+            label8.Size = new System.Drawing.Size(56, 17);
+            label8.TabIndex = 0;
+            label8.Text = "Server";
+            // 
+            // label9
+            // 
+            label9.AutoSize = true;
+            label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label9.Location = new System.Drawing.Point(8, 120);
+            label9.Name = "label9";
+            label9.Size = new System.Drawing.Size(112, 17);
+            label9.TabIndex = 7;
+            label9.Text = "Authentication";
+            // 
+            // pm_login_textBox
+            // 
+            pm_login_textBox.Enabled = false;
+            pm_login_textBox.Location = new System.Drawing.Point(13, 206);
+            pm_login_textBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_login_textBox.Name = "pm_login_textBox";
+            pm_login_textBox.Size = new System.Drawing.Size(306, 27);
+            pm_login_textBox.TabIndex = 2;
+            // 
+            // pm_authentication_comboBox
+            // 
+            pm_authentication_comboBox.Enabled = false;
+            pm_authentication_comboBox.FormattingEnabled = true;
+            pm_authentication_comboBox.Items.AddRange(new object[] { "Integrated Authentication", "SQL Server Authentication", "Azure Active Directory - Universal with MFA" });
+            pm_authentication_comboBox.Location = new System.Drawing.Point(13, 145);
+            pm_authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            pm_authentication_comboBox.Name = "pm_authentication_comboBox";
+            pm_authentication_comboBox.Size = new System.Drawing.Size(306, 28);
+            pm_authentication_comboBox.TabIndex = 1;
+            // 
+            // label10
+            // 
+            label10.AutoSize = true;
+            label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            label10.Location = new System.Drawing.Point(8, 182);
+            label10.Name = "label10";
+            label10.Size = new System.Drawing.Size(48, 17);
+            label10.TabIndex = 6;
+            label10.Text = "Login";
+            // 
+            // trustcert_check
+            // 
+            trustcert_check.AutoSize = true;
+            trustcert_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            trustcert_check.Location = new System.Drawing.Point(13, 496);
+            trustcert_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            trustcert_check.Name = "trustcert_check";
+            trustcert_check.Size = new System.Drawing.Size(200, 21);
+            trustcert_check.TabIndex = 20;
+            trustcert_check.Text = "Trust Server Certificate";
+            trustcert_check.UseVisualStyleBackColor = true;
+            // 
+            // pm_trustcert_check
+            // 
+            pm_trustcert_check.AutoSize = true;
+            pm_trustcert_check.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            pm_trustcert_check.Location = new System.Drawing.Point(11, 496);
+            pm_trustcert_check.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            pm_trustcert_check.Name = "pm_trustcert_check";
+            pm_trustcert_check.Size = new System.Drawing.Size(200, 21);
+            pm_trustcert_check.TabIndex = 21;
+            pm_trustcert_check.Text = "Trust Server Certificate";
+            pm_trustcert_check.UseVisualStyleBackColor = true;
+            // 
+            // DatabaseSelect
+            // 
+            AcceptButton = ok_button;
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = cancel_button;
+            ClientSize = new System.Drawing.Size(698, 740);
+            Controls.Add(groupBox2);
+            Controls.Add(groupBox1);
+            Controls.Add(ok_button);
+            Controls.Add(cancel_button);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "DatabaseSelect";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            Text = "Database Select";
+            groupBox1.ResumeLayout(false);
+            groupBox1.PerformLayout();
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            ResumeLayout(false);
         }
 
         #endregion
@@ -600,5 +611,7 @@ namespace SQLQueryStress
 		private System.Windows.Forms.Label label13;
 		private System.Windows.Forms.TextBox pm_additionalParameters_textBox;
 		private System.Windows.Forms.Label label14;
-	}
+        private System.Windows.Forms.CheckBox trustcert_check;
+        private System.Windows.Forms.CheckBox pm_trustcert_check;
+    }
 }

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -287,6 +287,8 @@ namespace SQLQueryStress
                     _localParamConnectionInfo.Encrypt = encrypt;
                 }
 
+                _localParamConnectionInfo.TrustServerCertificate = pm_trustcert_check.Checked;
+
                 if (!_localParamConnectionInfo.RequiresPassword && !_localParamConnectionInfo.AzureMFA)
                 {
                     _localParamConnectionInfo.Login = string.Empty;
@@ -335,6 +337,8 @@ namespace SQLQueryStress
             {
                 _localMainConnectionInfo.Encrypt = encrypt;
             }
+
+            _localMainConnectionInfo.TrustServerCertificate = trustcert_check.Checked;
 
             _localMainConnectionInfo.AzureMFA = authentication_comboBox.SelectedIndex == 2;
 

--- a/src/SQLQueryStress/DatabaseSelect.resx
+++ b/src/SQLQueryStress/DatabaseSelect.resx
@@ -1,4 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/src/SQLQueryStress/FormMain.resx
+++ b/src/SQLQueryStress/FormMain.resx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter


### PR DESCRIPTION
This checkin adds UI and functionatity to specify the `TrustServerCertificate=` value in the connection string. Self-signed certs (and any cert that isn't implicitly trusted by the chain) need this parameter to function correctly. Such certs are common in test environments.

See issue #161 