### PR TITLE
Make authentication method drop down only.

### DIFF
--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -96,6 +96,7 @@ namespace SQLQueryStress
             // 
             authentication_comboBox.FormattingEnabled = true;
             authentication_comboBox.Items.AddRange(new object[] { "Integrated Authentication", "SQL Server Authentication", "Azure Active Directory - Universal with MFA" });
+            authentication_comboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             authentication_comboBox.Location = new System.Drawing.Point(13, 145);
             authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             authentication_comboBox.Name = "authentication_comboBox";
@@ -518,6 +519,7 @@ namespace SQLQueryStress
             pm_authentication_comboBox.Enabled = false;
             pm_authentication_comboBox.FormattingEnabled = true;
             pm_authentication_comboBox.Items.AddRange(new object[] { "Integrated Authentication", "SQL Server Authentication", "Azure Active Directory - Universal with MFA" });
+            pm_authentication_comboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             pm_authentication_comboBox.Location = new System.Drawing.Point(13, 145);
             pm_authentication_comboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             pm_authentication_comboBox.Name = "pm_authentication_comboBox";

--- a/src/SQLQueryStress/DatabaseSelect.Designer.cs
+++ b/src/SQLQueryStress/DatabaseSelect.Designer.cs
@@ -243,7 +243,7 @@ namespace SQLQueryStress
             database_list_autorefresh.AutoSize = true;
             database_list_autorefresh.Checked = true;
             database_list_autorefresh.CheckState = System.Windows.Forms.CheckState.Checked;
-            database_list_autorefresh.Location = new System.Drawing.Point(207, 301);
+            database_list_autorefresh.Location = new System.Drawing.Point(207, 300);
             database_list_autorefresh.Name = "database_list_autorefresh";
             database_list_autorefresh.Size = new System.Drawing.Size(112, 24);
             database_list_autorefresh.TabIndex = 21;


### PR DESCRIPTION
Make authentication method drop down only. Similar as in SSMS. This list doesn't change often, so I think that way is preferable.

Move autorefresh checkbox to not overlap with database selection box. Started bothering me the longer I looked at the form.