### PR TITLE
Improve SQL editor readability: increase font size and fix syntax highlighting colors

### DIFF
--- a/src/SQLQueryStress/Resources/SQL.xshd
+++ b/src/SQLQueryStress/Resources/SQL.xshd
@@ -5,29 +5,29 @@
                   xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 
   <!-- T-SQL Reference: http://msdn.microsoft.com/de-de/library/ms189826%28v=sql.90%29.aspx -->
-  <Color name="Digits"     foreground="DarkBlue" exampleText="3.1415f"/>
-  <Color name="Comment" foreground="Green" exampleText="string text = &quot;Hello, World!&quot;"/>
-  <Color name="Punctuation" foreground="Red" exampleText="string text = &quot;Hello, World!&quot;"/>
+  <Color name="Digits"     foreground="#000000" exampleText="3.1415f"/>
+  <Color name="Comment" foreground="#008000" exampleText="string text = &quot;Hello, World!&quot;"/>
+  <Color name="Punctuation" foreground="#808080" exampleText="string text = &quot;Hello, World!&quot;"/>
 
-  <Color name="String" foreground="Olive" exampleText="string text = &quot;Hello, World!&quot;"/>
-  <Color name="String2" foreground="#993" exampleText="string text = &quot;Hello, World!&quot;"/>
+  <Color name="String" foreground="#FF0000" exampleText="string text = &quot;Hello, World!&quot;"/>
+  <Color name="String2" foreground="#FF0000" exampleText="string text = &quot;Hello, World!&quot;"/>
 
-  <Color name="Keyword" fontWeight="bold" foreground="Blue" exampleText="SELECT"/>
-  <Color name="Keyword1" fontWeight="normal" foreground="Blue" exampleText="NOCOUNT"/>
-  <Color name="GoKeyword" fontWeight="bold" foreground="Red" exampleText="GO"/>
+  <Color name="Keyword" fontWeight="bold" foreground="#0000FF" exampleText="SELECT"/>
+  <Color name="Keyword1" fontWeight="normal" foreground="#0000FF" exampleText="NOCOUNT"/>
+  <Color name="GoKeyword" fontWeight="bold" foreground="#FF0000" exampleText="GO"/>
 
-  <Color name="MethodCall" foreground="MidnightBlue" fontWeight="bold" />
+  <Color name="MethodCall" foreground="#795E26" fontWeight="bold" />
 
-  <Color name="Variable" foreground="Red"  exampleText="@Variable" />
-  <Color name="Variable1" foreground="Red" exampleText="@@Variable" />
+  <Color name="Variable" foreground="#FF0000"  exampleText="@Variable" />
+  <Color name="Variable1" foreground="#FF0000" exampleText="@@Variable" />
 
-  <Color name="ObjectReference" foreground="Teal" exampleText="Customer.Name" />
-  <Color name="ObjectReference1" foreground="Teal" exampleText="dbo.Customer.Name" />
+  <Color name="ObjectReference" foreground="#267F99" exampleText="Customer.Name" />
+  <Color name="ObjectReference1" foreground="#267F99" exampleText="dbo.Customer.Name" />
 
-  <Color name="ObjectReferenceInBrackets" foreground="Teal" exampleText="[Customer].[Name]" />
-  <Color name="ObjectReferenceInBrackets1" foreground="Teal" exampleText="[dbo].[Customer].[Name]" />
+  <Color name="ObjectReferenceInBrackets" foreground="#267F99" exampleText="[Customer].[Name]" />
+  <Color name="ObjectReferenceInBrackets1" foreground="#267F99" exampleText="[dbo].[Customer].[Name]" />
 
-  <Color name="CommentMarkerSetTodo"       foreground="Red"     fontWeight="bold" />
+  <Color name="CommentMarkerSetTodo"       foreground="#FF0000"     fontWeight="bold" />
   <Color name="CommentMarkerSetHackUndone" foreground="#E0E000" fontWeight="bold" />
 
   <RuleSet name="CommentMarkerSet">

--- a/src/SQLQueryStress/SqlControl.xaml
+++ b/src/SQLQueryStress/SqlControl.xaml
@@ -11,7 +11,7 @@
                 xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"  
                 x:Name="AvalonEdit"
                 FontFamily="Consolas"
-                FontSize="10pt" 
+                FontSize="12pt" 
                 ShowLineNumbers="True" 
                 LineNumbersForeground="#FF2B91AF" />
 


### PR DESCRIPTION
**Problem**

The SQL query editor had two issues affecting readability and usability:

1. Font size was set to 10pt, which is too small for comfortable query editing.
2. Syntax highlighting colors in SQL.xshd were defined using WPF named colors (e.g., "Blue", "Green", "Olive"). These named colors do not render reliably when WPF is hosted within a WinForms ElementHost, so keywords such as SELECT, FROM, and WHERE do not appear highlighted at all.

**Proposed Changes**
- Increased font size from 10pt to 12pt in SqlControl.xaml
- Replaced all WPF named colors in SQL.xshd with explicit hex values that match the SSMS default light theme:
- Keywords: #0000FF (blue, bold)
- Strings: #FF0000 (red)
- Comments: #008000 (green)
- Variables @var / @@var: #FF0000 (red)
- Functions/method calls: #795E26 (dark gold)
- Object references: #267F99 (teal)
- Punctuation: #808080 (gray)
- Numbers: #000000 (black)

Expected Result:
The SQL editor now renders with a familiar SSMS-style appearance, with clearly readable text
<img width="2483" height="700" alt="BeforeAfterPullRequest" src="https://github.com/user-attachments/assets/839957d9-7613-434f-bc8a-51d5c82774b4" />
 and properly colored syntax tokens